### PR TITLE
Add additional model tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -48,7 +48,7 @@ deps =
     pydocstyle
 skip_install = true
 commands =
-    flake8 --ignore=E203 --max-line-length 120 chemicalx/ tests/ examples/ setup.py
+    flake8 --ignore=E203,W503 --max-line-length 120 chemicalx/ tests/ examples/ setup.py
 
 [testenv:mypy]
 deps = mypy


### PR DESCRIPTION
# Summary
 
This PR adds tests to make sure that all models inherit from the correct base class, that their arguments are kwarg only, and that there are defaults for all arguments.
 
- [ ] Code passes all tests
- [x] Unit tests provided for these changes
- [x] Documentation and docstrings added for these changes

## Changes 

* add test for inheritance
* add test for arguments

## Additional remarks

This PR doesn't go as far as to check that all submodules from `chemicalx.models` are imported somewhere in `chemicalx/models/__init__.py`. We can leave that for checking manually during review, since all people making PRs for models should have them exposed before the PR can be accepted
