### PR TITLE
Expose dataset properties

### DIFF
--- a/chemicalx/constants.py
+++ b/chemicalx/constants.py
@@ -1,8 +1,11 @@
 """Constants for ChemicalX."""
 
+from torchdrug.data import Molecule
+from torchdrug.data.feature import atom_default
+
 __all__ = [
     "TORCHDRUG_NODE_FEATURES",
 ]
 
 #: The default number of node features on a molecule in torchdrug
-TORCHDRUG_NODE_FEATURES = 69
+TORCHDRUG_NODE_FEATURES = len(atom_default(Molecule.dummy_atom))

--- a/chemicalx/constants.py
+++ b/chemicalx/constants.py
@@ -1,0 +1,8 @@
+"""Constants for ChemicalX."""
+
+__all__ = [
+    "TORCHDRUG_NODE_FEATURES",
+]
+
+#: The default number of node features on a molecule in torchdrug
+TORCHDRUG_NODE_FEATURES = 69

--- a/chemicalx/data/datasetloader.py
+++ b/chemicalx/data/datasetloader.py
@@ -4,6 +4,7 @@ import io
 import json
 import urllib.request
 from functools import lru_cache
+from textwrap import dedent
 from typing import Dict
 
 import numpy as np
@@ -87,6 +88,16 @@ class DatasetLoader:
         context_feature_set.update(raw_data)
         return context_feature_set
 
+    @property
+    def num_contexts(self) -> int:
+        """Get the number of contexts."""
+        return len(self.get_context_features())
+
+    @property
+    def context_channels(self) -> int:
+        """Get the number of features for each context."""
+        return next(iter(self.get_context_features().values())).shape[1]
+
     @lru_cache(maxsize=1)
     def get_drug_features(self):
         """
@@ -104,6 +115,16 @@ class DatasetLoader:
         drug_feature_set.update(raw_data)
         return drug_feature_set
 
+    @property
+    def num_drugs(self) -> int:
+        """Get the number of drugs."""
+        return len(self.get_drug_features())
+
+    @property
+    def drug_channels(self) -> int:
+        """Get the number of features for each drug."""
+        return next(iter(self.get_drug_features().values()))["features"].shape[1]
+
     @lru_cache(maxsize=1)
     def get_labeled_triples(self):
         """
@@ -117,6 +138,26 @@ class DatasetLoader:
         labeled_triples = chemicalx.data.LabeledTriples()
         labeled_triples.update_from_pandas(raw_data)
         return labeled_triples
+
+    @property
+    def num_labeled_triples(self) -> int:
+        """Get the number of labeled triples."""
+        return len(self.get_labeled_triples())
+
+    def summarize(self) -> None:
+        """Summarize the dataset."""
+        print(
+            dedent(
+                f"""\
+            Name: {self.dataset_name}
+            Contexts: {self.num_contexts}
+            Context Feature Size: {self.context_channels}
+            Drugs: {self.num_drugs}
+            Drug Feature Size: {self.drug_channels}
+            Triples: {self.num_labeled_triples}
+        """
+            )
+        )
 
 
 class DrugCombDB(DatasetLoader):

--- a/chemicalx/data/datasetloader.py
+++ b/chemicalx/data/datasetloader.py
@@ -3,6 +3,7 @@
 import io
 import json
 import urllib.request
+from functools import lru_cache
 from typing import Dict
 
 import numpy as np
@@ -71,6 +72,7 @@ class DatasetLoader:
         raw_data = pd.read_csv(io.BytesIO(data_bytes), encoding="utf8", sep=",", dtype=types)
         return raw_data
 
+    @lru_cache(maxsize=1)
     def get_context_features(self):
         """
         Get the context feature set.
@@ -85,6 +87,7 @@ class DatasetLoader:
         context_feature_set.update(raw_data)
         return context_feature_set
 
+    @lru_cache(maxsize=1)
     def get_drug_features(self):
         """
         Get the drug feature set.
@@ -101,6 +104,7 @@ class DatasetLoader:
         drug_feature_set.update(raw_data)
         return drug_feature_set
 
+    @lru_cache(maxsize=1)
     def get_labeled_triples(self):
         """
         Get the labeled triples file from the storage.

--- a/chemicalx/data/labeledtriples.py
+++ b/chemicalx/data/labeledtriples.py
@@ -17,6 +17,10 @@ class LabeledTriples:
         self.types = {"drug_1": str, "drug_2": str, "context": str, "label": float}
         self.data = pd.DataFrame(columns=self.columns).astype(self.types)
 
+    def __len__(self) -> int:
+        """Get the number of triples."""
+        return len(self.data.index)
+
     def drop_duplicates(self):
         """Drop the duplicated entries."""
         self.data = self.data.drop_duplicates()

--- a/chemicalx/models/__init__.py
+++ b/chemicalx/models/__init__.py
@@ -18,6 +18,7 @@ from .ssiddi import SSIDDI
 __all__ = [
     "model_resolver",
     # Base models
+    "Model",
     "UnimplementedModel",
     # Implementations
     "CASTER",

--- a/chemicalx/models/deepsynergy.py
+++ b/chemicalx/models/deepsynergy.py
@@ -21,8 +21,8 @@ class DeepSynergy(Model):
     def __init__(
         self,
         *,
-        context_channels: int = 128,
-        drug_channels: int = 128,
+        context_channels: int,
+        drug_channels: int,
         input_hidden_channels: int = 32,
         middle_hidden_channels: int = 32,
         final_hidden_channels: int = 32,

--- a/chemicalx/models/epgcnds.py
+++ b/chemicalx/models/epgcnds.py
@@ -5,6 +5,7 @@ from torchdrug.data import PackedGraph
 from torchdrug.layers import MeanReadout
 from torchdrug.models import GraphConvolutionalNetwork
 
+from chemicalx.constants import TORCHDRUG_NODE_FEATURES
 from chemicalx.data import DrugPairBatch
 from chemicalx.models import Model
 
@@ -22,17 +23,22 @@ class EPGCNDS(Model):
     """
 
     def __init__(
-        self, *, drug_channels: int, hidden_channels: int = 32, middle_channels: int = 16, out_channels: int = 1
+        self,
+        *,
+        molecule_channels: int = TORCHDRUG_NODE_FEATURES,
+        hidden_channels: int = 32,
+        middle_channels: int = 16,
+        out_channels: int = 1,
     ):
         """Instantiate the EPGCN-DS model.
 
-        :param drug_channels: The number of molecular features.
+        :param molecule_channels: The number of molecular features.
         :param hidden_channels: The number of graph convolutional filters.
         :param middle_channels: The number of hidden layer neurons in the last layer.
         :param out_channels: The number of output channels.
         """
         super(EPGCNDS, self).__init__()
-        self.graph_convolution_in = GraphConvolutionalNetwork(drug_channels, hidden_channels)
+        self.graph_convolution_in = GraphConvolutionalNetwork(molecule_channels, hidden_channels)
         self.graph_convolution_out = GraphConvolutionalNetwork(hidden_channels, middle_channels)
         self.mean_readout = MeanReadout()
         self.final = torch.nn.Linear(middle_channels, out_channels)

--- a/chemicalx/models/epgcnds.py
+++ b/chemicalx/models/epgcnds.py
@@ -22,17 +22,17 @@ class EPGCNDS(Model):
     """
 
     def __init__(
-        self, *, in_channels: int = 128, hidden_channels: int = 32, middle_channels: int = 16, out_channels: int = 1
+        self, *, drug_channels: int, hidden_channels: int = 32, middle_channels: int = 16, out_channels: int = 1
     ):
         """Instantiate the EPGCN-DS model.
 
-        :param in_channels: The number of molecular features.
+        :param drug_channels: The number of molecular features.
         :param hidden_channels: The number of graph convolutional filters.
         :param middle_channels: The number of hidden layer neurons in the last layer.
         :param out_channels: The number of output channels.
         """
         super(EPGCNDS, self).__init__()
-        self.graph_convolution_in = GraphConvolutionalNetwork(in_channels, hidden_channels)
+        self.graph_convolution_in = GraphConvolutionalNetwork(drug_channels, hidden_channels)
         self.graph_convolution_out = GraphConvolutionalNetwork(hidden_channels, middle_channels)
         self.mean_readout = MeanReadout()
         self.final = torch.nn.Linear(middle_channels, out_channels)

--- a/examples/deepsynergy_examples.py
+++ b/examples/deepsynergy_examples.py
@@ -1,14 +1,16 @@
 """Example with DeepSynergy."""
 
 from chemicalx import pipeline
+from chemicalx.data import DrugCombDB
 from chemicalx.models import DeepSynergy
 
 
 def main():
     """Train and evaluate the DeepSynergy model."""
-    model = DeepSynergy(context_channels=112, drug_channels=256)
+    dataset = DrugCombDB()
+    model = DeepSynergy(context_channels=dataset.context_channels, drug_channels=dataset.drug_channels)
     results = pipeline(
-        dataset="drugcombdb",
+        dataset=dataset,
         model=model,
         batch_size=5120,
         epochs=100,

--- a/examples/epgcnds_examples.py
+++ b/examples/epgcnds_examples.py
@@ -8,7 +8,7 @@ from chemicalx.models import EPGCNDS
 def main():
     """Train and evaluate the EPGCNDS model."""
     dataset = DrugCombDB()
-    model = EPGCNDS(drug_channels=dataset.drug_channels)
+    model = EPGCNDS()
     results = pipeline(
         dataset=dataset,
         model=model,

--- a/examples/epgcnds_examples.py
+++ b/examples/epgcnds_examples.py
@@ -1,14 +1,16 @@
 """Example with EPGCNDS."""
 
 from chemicalx import pipeline
+from chemicalx.data import DrugCombDB
 from chemicalx.models import EPGCNDS
 
 
 def main():
     """Train and evaluate the EPGCNDS model."""
-    model = EPGCNDS(in_channels=69)
+    dataset = DrugCombDB()
+    model = EPGCNDS(drug_channels=dataset.drug_channels)
     results = pipeline(
-        dataset="drugcombdb",
+        dataset=dataset,
         model=model,
         optimizer_kwargs=dict(lr=0.01, weight_decay=10 ** -7),
         batch_size=1024,

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -52,7 +52,7 @@ class TestPipeline(unittest.TestCase):
 
     def test_train_contextless(self):
         """Test training and evaluating on a model that does not use context in its forward function."""
-        model = EPGCNDS(drug_channels=self.loader.drug_channels)
+        model = EPGCNDS()
         results = pipeline(
             dataset=self.loader,
             model=model,
@@ -90,7 +90,7 @@ class MetaModelTestCase(unittest.TestCase):
                 missing = {
                     name
                     for name, param in signature.parameters.items()
-                    if param.name != "self" and param.default is inspect.Parameter.empty
+                    if param.name not in skip and param.default is inspect.Parameter.empty
                 }
                 self.assertEqual(0, len(missing), msg=f"Missing default parameters for: {missing}")
                 positional = {
@@ -128,7 +128,7 @@ class TestModels(unittest.TestCase):
 
     def test_epgcnds(self):
         """Test EPGCNDS."""
-        model = EPGCNDS(drug_channels=self.loader.drug_channels)
+        model = EPGCNDS()
 
         optimizer = torch.optim.Adam(model.parameters(), lr=0.01, weight_decay=0.0001)
         model.train()


### PR DESCRIPTION
# Summary
 
It wasn't clear where the magic parameter numbers came from in the existing two examples - it turns out that a few of the inputs to a given model need to come from the dataset. This PR standardizes the names of those parameters and makes them easier to get from an instance of a dataset by exposing them as python properties

- [x] Code passes all tests
- [x] Unit tests provided for these changes
- [x] Documentation and docstrings added for these changes
- [x] Figure out where the number `69` for EPGCN-DS + DrugCombDB comes from (update: a constant from inside `torchdrug`)
 
## Changes 

* Add `lru_cache` to functions that get datasets' parts
* Expose several properties for a dataset including # drugs, # features for each drug, # contexts, # features for each context, and # triples.
* Rename parameters to models corresponding to `drug_channels` and `context_channels` to correspond respectively to # features for each drug and # features for each context.
* Removed default values for `drug_channels` and `context_channels`  (and update the test that checks for default values in each model's `def __init__()`
* Use setUpClass to reduce unnecessary reloading of datasets in testing
* Update examples for EPGCN-DS and DeepSynergy to reflect changes

