### PR TITLE
Remove check box that's automated with CI

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -10,7 +10,6 @@ Please ensure you have the following:
  
 _Please provide a high-level summary of the changes for the changes and notes for the reviewers_
  
-- [ ] Code passes all tests
 - [ ] Unit tests provided for these changes
 - [ ] Documentation and docstrings added for these changes
 


### PR DESCRIPTION
We don't need to go through the pain of contributors lying to us (and themselves) about checking that their code passed before pushing. The CI will do the talking.