### PR TITLE
Implement DeepDrug model

### DIFF
--- a/chemicalx/models/deepdrug.py
+++ b/chemicalx/models/deepdrug.py
@@ -62,11 +62,17 @@ class DeepDrug(Model):
 
     def unpack(self, batch: DrugPairBatch):
         """Return the context features, left drug molecules, and right drug molecules."""
-        return (
-            batch.context_features,
-            batch.drug_molecules_left,
-            batch.drug_molecules_right,
-        )
+        if self.context_channels > 0:
+            return (
+                batch.context_features,
+                batch.drug_molecules_left,
+                batch.drug_molecules_right,
+            )
+        else:
+            return (
+                batch.drug_molecules_left,
+                batch.drug_molecules_right,
+            )
 
     def forward(
         self, context_features: Optional[torch.FloatTensor], molecules_left: PackedGraph, molecules_right: PackedGraph

--- a/chemicalx/models/deepdrug.py
+++ b/chemicalx/models/deepdrug.py
@@ -77,8 +77,7 @@ class DeepDrug(Model):
         :param left: tuple containing the batch of left molecules and associated features
         :param right: tuple containing the batch of right molecules and associated features
 
-        :return Tuple[torch.FloatTensor, torch.FloatTensor]: tuple with left and right molecule batch features
-        after applying the torch Module
+        :return Tuple[torch.FloatTensor, torch.FloatTensor]: tuple with left and right molecule batch features after applying the torch Module
         """
         return layer(*left), layer(*right)
 

--- a/chemicalx/models/deepdrug.py
+++ b/chemicalx/models/deepdrug.py
@@ -1,7 +1,5 @@
 """An implementation of the DeepDrug model."""
 
-from typing import Optional
-
 import torch
 from torchdrug.data import PackedGraph
 from torchdrug.layers import GraphConv, MaxReadout

--- a/chemicalx/models/deepdrug.py
+++ b/chemicalx/models/deepdrug.py
@@ -49,7 +49,7 @@ class DeepDrug(Model):
 
         # add remaining GCN layers
         self.gcn_layer_list = torch.nn.ModuleList()
-        for i in range(num_gcn_layers - 1):
+        for _ in range(num_gcn_layers - 1):
             self.gcn_layer_list.append(
                 GraphConv(self.gcn_layer_hidden_size, self.gcn_layer_hidden_size, batch_norm=True)
             )
@@ -83,8 +83,7 @@ class DeepDrug(Model):
         features_right = self.graph_convolution_first(molecules_right, molecules_right.data_dict["node_feature"])
 
         # run remaining GCN layers
-        for i in range(self.num_gcn_layers - 1):
-            layer_i = self.gcn_layer_list[i]
+        for layer_i in self.gcn_layer_list:
             features_left = layer_i(molecules_left, features_left)
             features_right = layer_i(molecules_right, features_right)
 

--- a/chemicalx/models/deepdrug.py
+++ b/chemicalx/models/deepdrug.py
@@ -18,7 +18,7 @@ __all__ = [
 class DeepDrug(Model):
     """An implementation of the DeepDrug model.
 
-    .. based on:: https://www.biorxiv.org/content/biorxiv/early/2020/11/10/2020.11.09.375626.full.pdf
+    .. seealso:: 'DeepDrug: A general graph-based deep learning framework for drug relation prediction' by Cao et al. https://www.biorxiv.org/content/10.1101/2020.11.09.375626v1
     """
 
     def __init__(

--- a/chemicalx/models/deepdrug.py
+++ b/chemicalx/models/deepdrug.py
@@ -16,7 +16,7 @@ __all__ = [
 class DeepDrug(Model):
     """An implementation of the DeepDrug model.
 
-    .. see also:: https://github.com/AstraZeneca/chemicalx/issues/14
+    .. based on:: https://www.biorxiv.org/content/biorxiv/early/2020/11/10/2020.11.09.375626.full.pdf
     """
 
     def __init__(

--- a/chemicalx/models/deepdrug.py
+++ b/chemicalx/models/deepdrug.py
@@ -2,8 +2,7 @@
 
 import torch
 from torchdrug.data import PackedGraph
-from torchdrug.layers import MaxReadout
-from torchdrug.models import GraphConvolutionalNetwork
+from torchdrug.layers import GraphConv, MaxReadout
 
 from chemicalx.constants import TORCHDRUG_NODE_FEATURES
 from chemicalx.data import DrugPairBatch
@@ -42,15 +41,13 @@ class DeepDrug(Model):
         super(DeepDrug, self).__init__()
         self.num_gcn_layers = num_gcn_layers
         self.gcn_layer_hidden_size = gcn_layer_hidden_size
-        self.graph_convolution_first = GraphConvolutionalNetwork(
-            molecule_channels, self.gcn_layer_hidden_size, batch_norm=True
-        )
+        self.graph_convolution_first = GraphConv(molecule_channels, self.gcn_layer_hidden_size, batch_norm=True)
 
         # add remaining GCN layers
         self.gcn_layer_list = torch.nn.ModuleList()
         for i in range(num_gcn_layers - 1):
             self.gcn_layer_list.append(
-                GraphConvolutionalNetwork(self.gcn_layer_hidden_size, self.gcn_layer_hidden_size, batch_norm=True)
+                GraphConv(self.gcn_layer_hidden_size, self.gcn_layer_hidden_size, batch_norm=True)
             )
 
         self.max_readout = MaxReadout()
@@ -71,18 +68,14 @@ class DeepDrug(Model):
         self, context_features: torch.FloatTensor, molecules_left: PackedGraph, molecules_right: PackedGraph
     ) -> torch.FloatTensor:
 
-        features_left = self.graph_convolution_first(molecules_left, molecules_left.data_dict["node_feature"])[
-            "node_feature"
-        ]
-        features_right = self.graph_convolution_first(molecules_right, molecules_right.data_dict["node_feature"])[
-            "node_feature"
-        ]
+        features_left = self.graph_convolution_first(molecules_left, molecules_left.data_dict["node_feature"])
+        features_right = self.graph_convolution_first(molecules_right, molecules_right.data_dict["node_feature"])
 
         # run remaining GCN layers
         for i in range(self.num_gcn_layers - 1):
             layer_i = self.gcn_layer_list[i]
-            features_left = layer_i(molecules_left, features_left)["node_feature"]
-            features_right = layer_i(molecules_right, features_right)["node_feature"]
+            features_left = layer_i(molecules_left, features_left)
+            features_right = layer_i(molecules_right, features_right)
 
         features_left = self.max_readout(molecules_left, features_left)
         features_right = self.max_readout(molecules_right, features_right)

--- a/chemicalx/models/deepdrug.py
+++ b/chemicalx/models/deepdrug.py
@@ -1,10 +1,10 @@
 """An implementation of the DeepDrug model."""
 
+from typing import Optional
+
 import torch
 from torchdrug.data import PackedGraph
 from torchdrug.layers import GraphConv, MaxReadout
-
-from typing import Optional
 
 from chemicalx.constants import TORCHDRUG_NODE_FEATURES
 from chemicalx.data import DrugPairBatch

--- a/chemicalx/models/deepdrug.py
+++ b/chemicalx/models/deepdrug.py
@@ -57,6 +57,7 @@ class DeepDrug(Model):
         self.dropout = torch.nn.Dropout(p=dropout_rate)
         self.batch_norm = torch.nn.BatchNorm1d(self.middle_channels)
         self.final = torch.nn.Linear(self.middle_channels, out_channels)
+        self.context_channels = context_channels
 
     def unpack(self, batch: DrugPairBatch):
         """Return the context features, left drug molecules, and right drug molecules."""

--- a/chemicalx/models/deepdrug.py
+++ b/chemicalx/models/deepdrug.py
@@ -77,7 +77,8 @@ class DeepDrug(Model):
         :param left: tuple containing the batch of left molecules and associated features
         :param right: tuple containing the batch of right molecules and associated features
 
-        :return Tuple[torch.FloatTensor, torch.FloatTensor]: tuple with left and right molecule batch features after applying the torch Module
+        :return Tuple[torch.FloatTensor, torch.FloatTensor]: tuple with left and right molecule batch features
+            after applying the torch Module
         """
         return layer(*left), layer(*right)
 

--- a/chemicalx/models/deepdrug.py
+++ b/chemicalx/models/deepdrug.py
@@ -1,14 +1,88 @@
 """An implementation of the DeepDrug model."""
 
-from .base import UnimplementedModel
+import torch
+from torchdrug.data import PackedGraph
+from torchdrug.layers import MaxReadout
+from torchdrug.models import GraphConvolutionalNetwork
+
+from chemicalx.constants import TORCHDRUG_NODE_FEATURES
+from chemicalx.data import DrugPairBatch
+from chemicalx.models import Model
 
 __all__ = [
     "DeepDrug",
 ]
 
 
-class DeepDrug(UnimplementedModel):
+class DeepDrug(Model):
     """An implementation of the DeepDrug model.
 
-    .. seealso:: https://github.com/AstraZeneca/chemicalx/issues/14
+    .. see also:: https://github.com/AstraZeneca/chemicalx/issues/14
     """
+
+    def __init__(
+        self,
+        *,
+        context_channels: int = 112,
+        molecule_channels: int = TORCHDRUG_NODE_FEATURES,
+        num_gcn_layers: int = 4,
+        gcn_layer_hidden_size: int = 64,
+        out_channels: int = 1,
+    ):
+        """Instantiate the DeepDrug model.
+
+        :param context_channels: The number of contexts used for learning.
+        :param molecule_channels: The number of molecular features.
+        :param num_gcn_layers: Number of GCN layers
+        :param gcn_layer_hidden_size: number of hidden units in GCN layers
+        :param out_channels: The number of output channels.
+        """
+        super(DeepDrug, self).__init__()
+        self.num_gcn_layers = num_gcn_layers
+        self.gcn_layer_hidden_size = gcn_layer_hidden_size
+        self.graph_convolution_first = GraphConvolutionalNetwork(molecule_channels, self.gcn_layer_hidden_size)
+
+        # add remaining GCN layers
+        self.gcn_layer_list = torch.nn.ModuleList()
+        for i in range(num_gcn_layers - 1):
+            self.gcn_layer_list.append(
+                GraphConvolutionalNetwork(self.gcn_layer_hidden_size, self.gcn_layer_hidden_size)
+            )
+
+        self.max_readout = MaxReadout()
+        self.middle_channels = 2 * self.gcn_layer_hidden_size + context_channels  # left/right feats + context
+        self.final = torch.nn.Linear(self.middle_channels, out_channels)
+
+    def unpack(self, batch: DrugPairBatch):
+        """Return the context features, left drug molecules, and right drug molecules."""
+        return (
+            batch.context_features,
+            batch.drug_molecules_left,
+            batch.drug_molecules_right,
+        )
+
+    def forward(
+        self, context_features: torch.FloatTensor, molecules_left: PackedGraph, molecules_right: PackedGraph
+    ) -> torch.FloatTensor:
+
+        features_left = self.graph_convolution_first(molecules_left, molecules_left.data_dict["node_feature"])[
+            "node_feature"
+        ]
+        features_right = self.graph_convolution_first(molecules_right, molecules_right.data_dict["node_feature"])[
+            "node_feature"
+        ]
+
+        # run remaining GCN layers
+        for i in range(self.num_gcn_layers - 1):
+            layer_i = self.gcn_layer_list[i]
+            features_left = layer_i(molecules_left, features_left)["node_feature"]
+            features_right = layer_i(molecules_right, features_right)["node_feature"]
+
+        features_left = self.max_readout(molecules_left, features_left)
+        features_right = self.max_readout(molecules_right, features_right)
+
+        hidden = torch.cat([features_left, features_right, context_features], dim=1)
+        hidden = self.final(hidden)
+        hidden = torch.sigmoid(hidden)
+
+        return hidden

--- a/chemicalx/models/deepdrug.py
+++ b/chemicalx/models/deepdrug.py
@@ -18,7 +18,8 @@ __all__ = [
 class DeepDrug(Model):
     """An implementation of the DeepDrug model.
 
-    .. seealso:: 'DeepDrug: A general graph-based deep learning framework for drug relation prediction' by Cao et al. https://www.biorxiv.org/content/10.1101/2020.11.09.375626v1
+    .. seealso:: 'DeepDrug: A general graph-based deep learning framework for drug relation prediction' by Cao et al. \
+    https://www.biorxiv.org/content/10.1101/2020.11.09.375626v1
     """
 
     def __init__(

--- a/chemicalx/models/deepdrug.py
+++ b/chemicalx/models/deepdrug.py
@@ -33,7 +33,8 @@ class DeepDrug(Model):
     ):
         """Instantiate the DeepDrug model.
 
-        :param context_channels: The number of contexts used for learning. Set to 0 if not using any context.
+        :param context_channels: The number of contexts used for learning. Set to 0 if not using any context. In that
+        case make sure you're not calling forward() with the context feature tensor.
         :param molecule_channels: The number of molecular features.
         :param num_gcn_layers: Number of GCN layers.
         :param gcn_layer_hidden_size: number of hidden units in GCN layers

--- a/chemicalx/models/deepdrug.py
+++ b/chemicalx/models/deepdrug.py
@@ -25,7 +25,6 @@ class DeepDrug(Model):
     def __init__(
         self,
         *,
-        context_channels: int = 112,
         molecule_channels: int = TORCHDRUG_NODE_FEATURES,
         num_gcn_layers: int = 4,
         gcn_layer_hidden_size: int = 64,
@@ -34,8 +33,6 @@ class DeepDrug(Model):
     ):
         """Instantiate the DeepDrug model.
 
-        :param context_channels: The number of contexts used for learning. Set to 0 if not using any context. In that
-        case make sure you're not calling forward() with the context feature tensor.
         :param molecule_channels: The number of molecular features.
         :param num_gcn_layers: Number of GCN layers.
         :param gcn_layer_hidden_size: number of hidden units in GCN layers
@@ -55,30 +52,27 @@ class DeepDrug(Model):
             )
 
         self.max_readout = MaxReadout()
-        self.middle_channels = 2 * self.gcn_layer_hidden_size + context_channels  # left/right feats + context
+        self.middle_channels = 2 * self.gcn_layer_hidden_size
         self.dropout = torch.nn.Dropout(p=dropout_rate)
         self.batch_norm = torch.nn.BatchNorm1d(self.middle_channels)
         self.final = torch.nn.Linear(self.middle_channels, out_channels)
-        self.context_channels = context_channels
 
     def unpack(self, batch: DrugPairBatch):
-        """Return the context features, left drug molecules, and right drug molecules."""
-        if self.context_channels > 0:
-            return (
-                batch.context_features,
-                batch.drug_molecules_left,
-                batch.drug_molecules_right,
-            )
-        else:
-            return (
-                batch.drug_molecules_left,
-                batch.drug_molecules_right,
-            )
+        """Return the left drug molecules, and right drug molecules."""
+        return (
+            batch.drug_molecules_left,
+            batch.drug_molecules_right,
+        )
 
-    def forward(
-        self, context_features: Optional[torch.FloatTensor], molecules_left: PackedGraph, molecules_right: PackedGraph
-    ) -> torch.FloatTensor:
+    def forward(self, molecules_left: PackedGraph, molecules_right: PackedGraph) -> torch.FloatTensor:
+        """
+        Run a forward pass of the DeepDrug model.
 
+        :param molecules_left: Batched molecules for the left side drugs.
+        :param molecules_right: Batched molecules for the right side drugs.
+
+        :return: A column vector of predicted synergy scores.
+        """
         features_left = self.graph_convolution_first(molecules_left, molecules_left.data_dict["node_feature"])
         features_right = self.graph_convolution_first(molecules_right, molecules_right.data_dict["node_feature"])
 
@@ -90,10 +84,7 @@ class DeepDrug(Model):
         features_left = self.max_readout(molecules_left, features_left)
         features_right = self.max_readout(molecules_right, features_right)
 
-        if self.context_channels > 0:
-            hidden = torch.cat([features_left, features_right, context_features], dim=1)
-        else:
-            hidden = torch.cat([features_left, features_right], dim=1)
+        hidden = torch.cat([features_left, features_right], dim=1)
         hidden = self.batch_norm(hidden)
         hidden = self.dropout(hidden)
         hidden = self.final(hidden)

--- a/examples/deepdrug_examples.py
+++ b/examples/deepdrug_examples.py
@@ -1,0 +1,26 @@
+"""Example with DeepDrug."""
+
+from chemicalx import pipeline
+from chemicalx.data import DrugCombDB
+from chemicalx.models import DeepDrug
+
+
+def main():
+    """Train and evaluate the EPGCNDS model."""
+    dataset = DrugCombDB()
+    model = DeepDrug()
+    results = pipeline(
+        dataset=dataset,
+        model=model,
+        optimizer_kwargs=dict(lr=0.001),
+        batch_size=1024,
+        epochs=100,
+        context_features=True,
+        drug_features=True,
+        drug_molecules=True,
+    )
+    results.summarize()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/deepdrug_examples.py
+++ b/examples/deepdrug_examples.py
@@ -14,8 +14,8 @@ def main():
         model=model,
         optimizer_kwargs=dict(lr=0.001),
         batch_size=1024,
-        epochs=100,
-        context_features=True,
+        epochs=20,
+        context_features=False,
         drug_features=True,
         drug_molecules=True,
     )

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -170,7 +170,7 @@ class TestModels(unittest.TestCase):
 
     def test_deepdrug(self):
         """Test DeepDrug."""
-        model = DeepDrug()
+        model = DeepDrug(context_channels=288)
 
         optimizer = torch.optim.Adam(model.parameters(), lr=0.001)
         model.train()

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -58,7 +58,7 @@ class TestPipeline(unittest.TestCase):
         results = pipeline(
             dataset=self.loader,
             model=model,
-            optimizer_kwargs=dict(lr=0.01, weight_decay=10**-7),
+            optimizer_kwargs=dict(lr=0.01, weight_decay=10 ** -7),
             batch_size=1024,
             epochs=1,
             context_features=True,

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -191,7 +191,11 @@ class TestModels(unittest.TestCase):
         loss = torch.nn.BCELoss()
         for batch in self.generator:
             optimizer.zero_grad()
-            prediction = model_0(molecules_left=batch.drug_molecules_left, molecules_right=batch.drug_molecules_right)
+            prediction = model_0(
+                context_features=None,
+                molecules_left=batch.drug_molecules_left,
+                molecules_right=batch.drug_molecules_right,
+            )
             output = loss(prediction, batch.labels)
             output.backward()
             optimizer.step()

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -58,7 +58,7 @@ class TestPipeline(unittest.TestCase):
         results = pipeline(
             dataset=self.loader,
             model=model,
-            optimizer_kwargs=dict(lr=0.01, weight_decay=10 ** -7),
+            optimizer_kwargs=dict(lr=0.01, weight_decay=10**-7),
             batch_size=1024,
             epochs=1,
             context_features=True,

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -170,32 +170,14 @@ class TestModels(unittest.TestCase):
 
     def test_deepdrug(self):
         """Test DeepDrug."""
-        model = DeepDrug(context_channels=288)
+        model = DeepDrug()
 
         optimizer = torch.optim.Adam(model.parameters(), lr=0.001)
         model.train()
         loss = torch.nn.BCELoss()
         for batch in self.generator:
             optimizer.zero_grad()
-            prediction = model(batch.context_features, batch.drug_molecules_left, batch.drug_molecules_right)
-            output = loss(prediction, batch.labels)
-            output.backward()
-            optimizer.step()
-            assert prediction.shape[0] == batch.labels.shape[0]
-
-        # check if it also works without context features
-        model_0 = DeepDrug(context_channels=0)
-
-        optimizer = torch.optim.Adam(model_0.parameters(), lr=0.001)
-        model_0.train()
-        loss = torch.nn.BCELoss()
-        for batch in self.generator:
-            optimizer.zero_grad()
-            prediction = model_0(
-                context_features=None,
-                molecules_left=batch.drug_molecules_left,
-                molecules_right=batch.drug_molecules_right,
-            )
+            prediction = model(batch.drug_molecules_left, batch.drug_molecules_right)
             output = loss(prediction, batch.labels)
             output.backward()
             optimizer.step()

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -170,8 +170,32 @@ class TestModels(unittest.TestCase):
 
     def test_deepdrug(self):
         """Test DeepDrug."""
-        model = DeepDrug(x=2)
-        assert model.x == 2
+        model = DeepDrug()
+
+        optimizer = torch.optim.Adam(model.parameters(), lr=0.001)
+        model.train()
+        loss = torch.nn.BCELoss()
+        for batch in self.generator:
+            optimizer.zero_grad()
+            prediction = model(batch.context_features, batch.drug_molecules_left, batch.drug_molecules_right)
+            output = loss(prediction, batch.labels)
+            output.backward()
+            optimizer.step()
+            assert prediction.shape[0] == batch.labels.shape[0]
+
+        # check if it also works without context features
+        model_0 = DeepDrug(context_channels=0)
+
+        optimizer = torch.optim.Adam(model_0.parameters(), lr=0.001)
+        model_0.train()
+        loss = torch.nn.BCELoss()
+        for batch in self.generator:
+            optimizer.zero_grad()
+            prediction = model_0(molecules_left=batch.drug_molecules_left, molecules_right=batch.drug_molecules_right)
+            output = loss(prediction, batch.labels)
+            output.backward()
+            optimizer.step()
+            assert prediction.shape[0] == batch.labels.shape[0]
 
     def test_deepsynergy(self):
         """Test DeepSynergy."""


### PR DESCRIPTION
Closes #14

Added the DeepDrug model, trying to copy as much as possible from their approach. The paper didn't use any context features, but I implemented the model so that it could be used in both ways. I ran the model with and without context feats on DrugCombDB with around 0.76 AUROC (no context features led to a minor drop in AUROC).

Provided an example that runs the model and a unit test which tests both the context and no-context modes of this model.
 
- [X] Unit tests provided for these changes
- [X] Documentation and docstrings added for these changes
