### PR TITLE
Simplify existing models

### DIFF
--- a/chemicalx/models/deepsynergy.py
+++ b/chemicalx/models/deepsynergy.py
@@ -1,7 +1,7 @@
 r"""An implementation of the DeepSynergy model."""
 
 import torch
-import torch.nn.functional as F  # noqa:N812
+from torch import nn
 
 from chemicalx.data import DrugPairBatch
 from chemicalx.models import Model
@@ -39,12 +39,18 @@ class DeepSynergy(Model):
         :param out_channels: The number of output channels.
         :param dropout_rate: The rate of dropout before the scoring head is used.
         """
-        super(DeepSynergy, self).__init__()
-        self.encoder = torch.nn.Linear(drug_channels + drug_channels + context_channels, input_hidden_channels)
-        self.hidden_first = torch.nn.Linear(input_hidden_channels, middle_hidden_channels)
-        self.hidden_second = torch.nn.Linear(middle_hidden_channels, final_hidden_channels)
-        self.dropout = torch.nn.Dropout(dropout_rate)
-        self.scoring_head = torch.nn.Linear(final_hidden_channels, out_channels)
+        super().__init__()
+        self.layers = nn.Sequential(
+            nn.Linear(drug_channels + drug_channels + context_channels, input_hidden_channels),
+            nn.ReLU(),
+            nn.Linear(input_hidden_channels, middle_hidden_channels),
+            nn.ReLU(),
+            nn.Linear(middle_hidden_channels, final_hidden_channels),
+            nn.ReLU(),
+            nn.Dropout(dropout_rate),
+            nn.Linear(final_hidden_channels, out_channels),
+            nn.Sigmoid(),
+        )
 
     def unpack(self, batch: DrugPairBatch):
         """Return the context features, left drug features, and right drug features."""
@@ -64,20 +70,11 @@ class DeepSynergy(Model):
         Run a forward pass of the DeepSynergy model.
 
         Args:
-            context_features (torch.FloatTensor): A matrix of biological context features.
-            drug_features_left (torch.FloatTensor): A matrix of head drug features.
-            drug_features_right (torch.FloatTensor): A matrix of tail drug features.
+            context_features: A matrix of biological context features.
+            drug_features_left: A matrix of head drug features.
+            drug_features_right: A matrix of tail drug features.
         Returns:
-            hidden (torch.FloatTensor): A column vector of predicted synergy scores.
+            : A column vector of predicted synergy scores.
         """
         hidden = torch.cat([context_features, drug_features_left, drug_features_right], dim=1)
-        hidden = self.encoder(hidden)
-        hidden = F.relu(hidden)
-        hidden = self.hidden_first(hidden)
-        hidden = F.relu(hidden)
-        hidden = self.hidden_second(hidden)
-        hidden = F.relu(hidden)
-        hidden = self.dropout(hidden)
-        hidden = self.scoring_head(hidden)
-        hidden = torch.sigmoid(hidden)
-        return hidden
+        return self.layers(hidden)

--- a/chemicalx/models/epgcnds.py
+++ b/chemicalx/models/epgcnds.py
@@ -1,6 +1,7 @@
 """An implementation of the EPGCN-DS model."""
 
 import torch
+from torch import nn
 from torchdrug.data import PackedGraph
 from torchdrug.layers import MeanReadout
 from torchdrug.models import GraphConvolutionalNetwork
@@ -41,7 +42,7 @@ class EPGCNDS(Model):
         self.graph_convolution_in = GraphConvolutionalNetwork(molecule_channels, hidden_channels)
         self.graph_convolution_out = GraphConvolutionalNetwork(hidden_channels, middle_channels)
         self.mean_readout = MeanReadout()
-        self.final = torch.nn.Linear(middle_channels, out_channels)
+        self.final = nn.Sequential(nn.Linear(middle_channels, out_channels), nn.Sigmoid())
 
     def unpack(self, batch: DrugPairBatch):
         """Return the left molecular graph and right molecular graph."""
@@ -69,5 +70,5 @@ class EPGCNDS(Model):
         features_left = self._forward_molecules(molecules_left)
         features_right = self._forward_molecules(molecules_right)
         hidden = features_left + features_right
-        hidden = torch.sigmoid(self.final(hidden))
+        hidden = self.final(hidden)
         return hidden


### PR DESCRIPTION
This pull request simplifies the three models by doing the following:

1. Switch to using the module interface instead of the functional interface for elements like ReLU, sigmoid, and dropout
2. Use `nn.Sequential()` to reduce stacked calls to modules/functions. This has the added benefit of removing confusing nomenclature
3. Group related functionality into helper functions (e.g., when the same thing is called on the left molecule and right molecule)
4. Improve documentation