### PR TITLE
Standardize documentation style with `darglint`

### DIFF
--- a/chemicalx/data/batchgenerator.py
+++ b/chemicalx/data/batchgenerator.py
@@ -33,14 +33,13 @@ class BatchGenerator(Iterator[DrugPairBatch]):
     ):
         """Initialize a batch generator.
 
-        Args:
-            batch_size: Number of drug pairs per batch.
-            context_features: Indicator whether the batch should include biological context features.
-            drug_features: Indicator whether the batch should include drug features.
-            drug_molecules: Indicator whether the batch should include drug molecules
-            context_feature_set: A context feature set for feature generation.
-            drug_feature_set: A drug feature set for feature generation.
-            labeled_triples: A labeled triples object used to generate batches.
+        :param batch_size: Number of drug pairs per batch.
+        :param context_features: Indicator whether the batch should include biological context features.
+        :param drug_features: Indicator whether the batch should include drug features.
+        :param drug_molecules: Indicator whether the batch should include drug molecules
+        :param context_feature_set: A context feature set for feature generation.
+        :param drug_feature_set: A drug feature set for feature generation.
+        :param labeled_triples: A labeled triples object used to generate batches.
         """
         self.batch_size = batch_size
         self.context_features = context_features
@@ -53,10 +52,8 @@ class BatchGenerator(Iterator[DrugPairBatch]):
     def _get_context_features(self, context_identifiers: Iterable[str]) -> Optional[torch.FloatTensor]:
         """Get the context features as a matrix.
 
-        Args:
-            context_identifiers (pd.Series): The context identifiers of interest.
-        Returns:
-            context_features (torch.FloatTensor): The matrix of biological context features.
+        :param context_identifiers: The context identifiers of interest.
+        :returns: The matrix of biological context features.
         """
         if not self.context_features or self.context_feature_set is None:
             return None
@@ -65,10 +62,8 @@ class BatchGenerator(Iterator[DrugPairBatch]):
     def _get_drug_features(self, drug_identifiers: Iterable[str]) -> Optional[torch.FloatTensor]:
         """Get the global drug features as a matrix.
 
-        Args:
-            drug_identifiers: The drug identifiers of interest.
-        Returns:
-            drug_features: The matrix of drug features.
+        :param drug_identifiers: The drug identifiers of interest.
+        :returns: The matrix of drug features.
         """
         if not self.drug_features or self.drug_feature_set is None:
             return None
@@ -77,10 +72,8 @@ class BatchGenerator(Iterator[DrugPairBatch]):
     def _get_drug_molecules(self, drug_identifiers: Iterable[str]) -> Optional[PackedGraph]:
         """Get the molecular structure of drugs.
 
-        Args:
-            drug_identifiers: The drug identifiers of interest.
-        Returns:
-            molecules: The molecules diagonally batched together for message passing.
+        :param drug_identifiers: The drug identifiers of interest.
+        :returns: The molecules diagonally batched together for message passing.
         """
         if not self.drug_molecules or self.drug_feature_set is None:
             return None
@@ -90,10 +83,8 @@ class BatchGenerator(Iterator[DrugPairBatch]):
     def _transform_labels(cls, labels: Sequence[float]) -> torch.FloatTensor:
         """Transform the labels from a chunk of the labeled triples frame.
 
-        Args:
-            labels: The drug pair binary labels.
-        Returns:
-            labels : The label target vector as a column vector.
+        :param labels: The drug pair binary labels.
+        :returns: The label target vector as a column vector.
         """
         return torch.FloatTensor(np.array(labels).reshape(-1, 1))
 
@@ -101,10 +92,8 @@ class BatchGenerator(Iterator[DrugPairBatch]):
         """
         Generate a batch of drug features, molecules, context features and labels for a set of pairs.
 
-        Args:
-            batch_frame (pd.DataFrame): The labeled pairs of interest.
-        Returns:
-            batch (DrugPairBatch): A batch of tensors for the pairs.
+        :param batch_frame: The labeled pairs of interest.
+        :Returns: A batch of tensors for the pairs.
         """
         drug_features_left = self._get_drug_features(batch_frame["drug_1"])
         drug_molecules_left = self._get_drug_molecules(batch_frame["drug_1"])

--- a/chemicalx/data/contextfeatureset.py
+++ b/chemicalx/data/contextfeatureset.py
@@ -21,9 +21,7 @@ class ContextFeatureSet(UserDict, Mapping[str, torch.FloatTensor]):
     def get_feature_matrix(self, contexts: Iterable[str]) -> torch.FloatTensor:
         """Get the feature matrix for a list of contexts.
 
-        Args:
-            contexts: A list of context identifiers.
-        Return:
-            features: A matrix of context features.
+        :param contexts: A list of context identifiers.
+        :returns: A matrix of context features.
         """
         return torch.cat([self.data[context] for context in contexts])

--- a/chemicalx/data/drugfeatureset.py
+++ b/chemicalx/data/drugfeatureset.py
@@ -30,19 +30,15 @@ class DrugFeatureSet(UserDict, Mapping[str, Mapping[str, Union[torch.FloatTensor
     def get_feature_matrix(self, drugs: Iterable[str]) -> torch.FloatTensor:
         """Get the drug feature matrix for a list of drugs.
 
-        Args:
-            drugs: A list of drug identifiers.
-        Return:
-            : A matrix of drug features.
+        :param drugs: A list of drug identifiers.
+        :returns: A matrix of drug features.
         """
         return torch.cat([self.data[drug]["features"] for drug in drugs])
 
     def get_molecules(self, drugs: Iterable[str]) -> PackedGraph:
         """Get the molecular structures.
 
-        Args:
-            drugs: A list of drug identifiers.
-        Return:
-            : The molecules batched together for message passing.
+        :param drugs: A list of drug identifiers.
+        :returns: The molecules batched together for message passing.
         """
         return Graph.pack([self.data[drug]["molecule"] for drug in drugs])

--- a/chemicalx/data/labeledtriples.py
+++ b/chemicalx/data/labeledtriples.py
@@ -32,85 +32,43 @@ class LabeledTriples:
         """
         Add the triples in two LabeledTriples objects together - syntactic sugar for '+'.
 
-        Args:
-            value: Another LabeledTriples object for the addition.
-        Returns:
-            : A LabeledTriples object after the addition.
+        :param value: Another LabeledTriples object for the addition.
+        :returns: A LabeledTriples object after the addition.
         """
         return LabeledTriples(pd.concat([self.data, value.data]))
 
     def get_drug_count(self) -> int:
-        """
-        Get the number of drugs in the labeled triples dataset.
-
-        Returns
-            int: The number of unique compounds in the labeled triples dataset.
-        """
+        """Get the number of drugs in the labeled triples dataset."""
         return pd.unique(self.data[["drug_1", "drug_2"]].values.ravel("K")).shape[0]
 
     def get_context_count(self) -> int:
-        """
-        Get the number of unique contexts in the labeled triples dataset.
-
-        Returns
-            int: The number of unique contexts in the labeled triples dataset.
-        """
+        """Get the number of unique contexts in the labeled triples dataset."""
         return self.data["context"].nunique()
 
     def get_combination_count(self) -> int:
-        """
-        Get the number of unique drug pairs in the labeled triples dataset.
-
-        Returns
-            int: The number of unique pairs in the labeled triples dataset.
-        """
+        """Get the number of unique drug pairs in the labeled triples dataset."""
         combination_count = self.data[["drug_1", "drug_2"]].drop_duplicates().shape[0]
         return combination_count
 
     def get_labeled_triple_count(self) -> int:
-        """
-        Get the number of triples in the labeled triples dataset.
-
-        Returns
-            int: The number of triples in the labeled triples dataset.
-        """
+        """Get the number of triples in the labeled triples dataset."""
         triple_count = self.data.shape[0]
         return triple_count
 
     def get_positive_count(self) -> int:
-        """
-        Get the number of positive triples in the dataset.
-
-        Returns
-            int: The number of positive triples.
-        """
+        """Get the number of positive triples in the dataset."""
         return int(self.data["label"].sum())
 
     def get_negative_count(self) -> int:
-        """
-        Get the number of negative triples in the dataset.
-
-        Returns
-            int: The number of negative triples.
-        """
+        """Get the number of negative triples in the dataset."""
         return self.get_labeled_triple_count() - self.get_positive_count()
 
     def get_positive_rate(self) -> float:
-        """
-        Get the ratio of positive triples in the dataset.
-
-        Returns
-            float: The ratio of positive triples.
-        """
+        """Get the ratio of positive triples in the dataset."""
         return self.data["label"].mean()
 
     def get_negative_rate(self) -> float:
-        """
-        Get the ratio of positive triples in the dataset.
-
-        Returns
-            float: The ratio of negative triples.
-        """
+        """Get the ratio of positive triples in the dataset."""
         return 1.0 - self.data["label"].mean()
 
     def train_test_split(
@@ -119,12 +77,9 @@ class LabeledTriples:
         """
         Split the LabeledTriples object for training and testing.
 
-        Args:
-            train_size: The ratio of training triples. Default is 0.8 if None is passed.
-            random_state: The random seed. Default is 42. Set to none for no fixed seed.
-        Returns
-            train_labeled_triples (LabeledTriples): The training triples.
-            test_labeled_triples (LabeledTriples): The testing triples.
+        :param train_size: The ratio of training triples. Default is 0.8 if None is passed.
+        :param random_state: The random seed. Default is 42. Set to none for no fixed seed.
+        :returns: A pair of training triples and testing triples
         """
         train_data, test_data = train_test_split(self.data, train_size=train_size or 0.8, random_state=random_state)
         return LabeledTriples(train_data), LabeledTriples(test_data)

--- a/chemicalx/models/deepsynergy.py
+++ b/chemicalx/models/deepsynergy.py
@@ -66,15 +66,12 @@ class DeepSynergy(Model):
         drug_features_left: torch.FloatTensor,
         drug_features_right: torch.FloatTensor,
     ) -> torch.FloatTensor:
-        """
-        Run a forward pass of the DeepSynergy model.
+        """Run a forward pass of the DeepSynergy model.
 
-        Args:
-            context_features: A matrix of biological context features.
-            drug_features_left: A matrix of head drug features.
-            drug_features_right: A matrix of tail drug features.
-        Returns:
-            : A column vector of predicted synergy scores.
+        :param context_features: A matrix of biological context features.
+        :param drug_features_left: A matrix of head drug features.
+        :param drug_features_right: A matrix of tail drug features.
+        :returns: A column vector of predicted synergy scores.
         """
         hidden = torch.cat([context_features, drug_features_left, drug_features_right], dim=1)
         return self.layers(hidden)

--- a/chemicalx/models/epgcnds.py
+++ b/chemicalx/models/epgcnds.py
@@ -58,14 +58,11 @@ class EPGCNDS(Model):
         return features
 
     def forward(self, molecules_left: PackedGraph, molecules_right: PackedGraph) -> torch.FloatTensor:
-        """
-        Run a forward pass of the EPGCN-DS model.
+        """Run a forward pass of the EPGCN-DS model.
 
-        Args:
-            molecules_left: Batched molecules for the left side drugs.
-            molecules_right: Batched molecules for the right side drugs.
-        Returns:
-            : A column vector of predicted synergy scores.
+        :param molecules_left: Batched molecules for the left side drugs.
+        :param molecules_right: Batched molecules for the right side drugs.
+        :returns: A column vector of predicted synergy scores.
         """
         features_left = self._forward_molecules(molecules_left)
         features_right = self._forward_molecules(molecules_right)

--- a/chemicalx/models/matchmaker.py
+++ b/chemicalx/models/matchmaker.py
@@ -73,15 +73,12 @@ class MatchMaker(Model):
         drug_features_left: torch.FloatTensor,
         drug_features_right: torch.FloatTensor,
     ) -> torch.FloatTensor:
-        """
-        Run a forward pass of the MatchMaker model.
+        """Run a forward pass of the MatchMaker model.
 
-        Args:
-            context_features: A matrix of biological context features.
-            drug_features_left: A matrix of head drug features.
-            drug_features_right: A matrix of tail drug features.
-        Returns:
-            hidden: A column vector of predicted synergy scores.
+        :param context_features: A matrix of biological context features.
+        :param drug_features_left: A matrix of head drug features.
+        :param drug_features_right: A matrix of tail drug features.
+        :returns: A column vector of predicted synergy scores.
         """
         # The left drug
         hidden_left = torch.cat([context_features, drug_features_left], dim=1)

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -11,7 +11,7 @@ Please ensure you have the following:
 _Please provide a high-level summary of the changes for the changes and notes for the reviewers_
  
 - [ ] Unit tests provided for these changes
-- [ ] Documentation and docstrings added for these changes
+- [ ] Documentation and docstrings added for these changes using the [sphinx style](https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html)
 
 ## Changes 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,10 @@
 [metadata]
 long_description = file: README.md
 long_description_content_type = text/markdown
+
+##########################
+# Darglint Configuration #
+##########################
+[darglint]
+docstring_style = sphinx
+strictness = short

--- a/tox.ini
+++ b/tox.ini
@@ -40,6 +40,7 @@ description = Run linters.
 
 [testenv:flake8]
 deps =
+    darglint
     flake8
     flake8-black
     flake8-bugbear


### PR DESCRIPTION
# Summary
 
This PR adds the `darglint` plugin for `flake8`, whose job it is to check that documentation is provided in the correct format.
 
- [x] Unit tests provided for these changes
- [x] Documentation and docstrings added for these changes

## Changes 

* Add `darglint` to the `flake8` environment in `tox.ini`
* Add `darglint` configuration  in `setup.cfg` where I set `sphinx` as the preferred style for chemicalx. Previously, people looked towards the numpy and google styles since they helped reduce clutter, at the cost of taking a huge number of lines and leaving tons of dead whitespace. Now that type hints are first class in the python langauge, these formats seem a bit too verbose and the sphinx style is now best again
* Update all code to pass new tests
