### PR TITLE
Add GCN-BMP

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
         name: black
         stages: [commit]
         language: system
-        entry: black -l 120 ./chemicalx/. ./tests/. setup.py
+        entry: black -l 120 -t py38 ./chemicalx/. ./tests/. setup.py
         types: [python]
 
       - id: flake8

--- a/chemicalx/models/gcnbmp.py
+++ b/chemicalx/models/gcnbmp.py
@@ -102,7 +102,7 @@ class AttentionPooling(nn.Module):
 
 class GCNBMPEncoder(nn.Module, core.Configurable):
     def __init__(self, input_dim, hidden_dims, num_relation, edge_input_dim=None, short_cut=False, batch_norm=False,
-                 activation="relu", concat_hidden=False):
+                 activation="sigmoid", concat_hidden=False):
         """Instantiate the GCN-BMP encoder.
         :param input_dim (int): input dimension.
         :param hidden_dims (list of int): hidden dimensions.
@@ -183,6 +183,7 @@ class GCNBMP(Model):
         self,
         *,
         molecule_channels: int = TORCHDRUG_NODE_FEATURES,
+        num_relations: int = 4, # TODO: This default value should be set by a dataset-specific constant
         hidden_channels: int = 16,
         hidden_conv_layers: int = 1,
         out_channels: int = 1,
@@ -195,7 +196,7 @@ class GCNBMP(Model):
         """
         super(GCNBMP, self).__init__()
 
-        self.graph_convolutions = GCNBMPEncoder(molecule_channels, [hidden_channels for i in range(hidden_conv_layers)], 4)
+        self.graph_convolutions = GCNBMPEncoder(molecule_channels, [hidden_channels for i in range(hidden_conv_layers)], num_relations)
 
         self.attention_readout_left = AttentionPooling(molecule_channels, hidden_channels)
         self.attention_readout_right = AttentionPooling(molecule_channels, hidden_channels)

--- a/chemicalx/models/gcnbmp.py
+++ b/chemicalx/models/gcnbmp.py
@@ -40,8 +40,15 @@ def circular_correlation(left_x: torch.FloatTensor, right_x: torch.FloatTensor) 
 
 
 class Highway(nn.Module):
+    """
+    The Highway update layer from [highway].
+
+    .. [highway] `Highway Networks
+       <https://arxiv.org/abs/1505.00387>`_
+    """
+
     def __init__(self, input_size: int, prev_input_size: int):
-        """Instantiate the Highway update layer based on https://arxiv.org/abs/1505.00387
+        """Instantiate the Highway update layer
         :param input_size: current representation size.
         :param prev_input_size: size of the representation obtained by the previous convolutional layer.
         """
@@ -71,6 +78,13 @@ class Highway(nn.Module):
 
 
 class AttentionPooling(nn.Module):
+    """
+    The Attention pooling layer from [gcnbmp].
+
+    .. [gcnbmp] `GCN-BMP: Investigating graph representation learning for DDI prediction task
+       <https://www.sciencedirect.com/science/article/pii/S1046202320300608>`_
+    """
+
     def __init__(self, molecule_channels: int, hidden_channels: int):
         """Instantiate the Attention pooling layer
         :param molecules_channels: input node features (layer 0 of the backbone).
@@ -103,6 +117,13 @@ class AttentionPooling(nn.Module):
 
 
 class GCNBMPEncoder(nn.Module, core.Configurable):
+    """
+    The drug encoding backbone from [gcnbmp].
+
+    .. [gcnbmp] `GCN-BMP: Investigating graph representation learning for DDI prediction task
+       <https://www.sciencedirect.com/science/article/pii/S1046202320300608>`_
+    """
+
     def __init__(
         self,
         input_dim: int,
@@ -131,9 +152,7 @@ class GCNBMPEncoder(nn.Module, core.Configurable):
         self.layers = nn.ModuleList()
         for left_dim, right_dim in pairwise(self.dims):
             self.layers.append(
-                layers.RelationalGraphConv(
-                    left_dim, right_dim, num_relation, edge_input_dim, batch_norm, activation
-                )
+                layers.RelationalGraphConv(left_dim, right_dim, num_relation, edge_input_dim, batch_norm, activation)
             )
             self.layers.append(Highway(right_dim, left_dim))
 

--- a/chemicalx/models/gcnbmp.py
+++ b/chemicalx/models/gcnbmp.py
@@ -1,15 +1,16 @@
 """An implementation of the GCNBMP model."""
-from collections.abc import Sequence
-from typing import List, Optional, Tuple
+
+from typing import List, Optional, Tuple, Union
 
 import torch
-import torch.nn as nn
-import torch.nn.functional as F  # noqa:N812
 import torchdrug
 from more_itertools import chunked, pairwise
+from torch import nn
 from torch.fft import fft, ifft
+from torch.nn import functional as F  # noqa:N812
 from torch_scatter import scatter_add
 from torchdrug import core, layers
+from torchdrug.data import PackedGraph
 
 from chemicalx.constants import TORCHDRUG_NODE_FEATURES
 from chemicalx.data import DrugPairBatch
@@ -20,76 +21,66 @@ __all__ = [
 ]
 
 
-def circular_correlation(left_x: torch.FloatTensor, right_x: torch.FloatTensor) -> torch.FloatTensor:
-    """
-    Compute the circular correlation of two vectors a and b via their fast fourier transforms.
+def circular_correlation(left: torch.FloatTensor, right: torch.FloatTensor) -> torch.FloatTensor:
+    """Compute the circular correlation of two vectors ``left`` and ``right`` via their Fast Fourier Transforms.
 
-    :param left_x: Molecular representations on the left.
-    :param right_x: Molecular representations on the right.
+    :param left: the left vector
+    :param right: the right vector
     :returns: Joint representation by circular correlation.
     """
-    left_x_cfft = torch.conj(fft(left_x))
-    right_x_fft = fft(right_x)
+    left_x_cfft = torch.conj(fft(left))
+    right_x_fft = fft(right)
     circ_corr = ifft(torch.mul(left_x_cfft, right_x_fft))
     return circ_corr.real
 
 
 class Highway(nn.Module):
-    """
-    The Highway update layer from [highway].
+    """The Highway update layer from [srivastava2015]_.
 
-    .. [highway] `Highway Networks
-       <https://arxiv.org/abs/1505.00387>`_
+    .. [srivastava2015] Srivastava, R. K., *et al.* (2015).
+       `Highway Networks <http://arxiv.org/abs/1505.00387>`_.
+       *arXiv*, 1505.00387.
     """
 
     def __init__(self, input_size: int, prev_input_size: int):
-        """
-        Instantiate the Highway update layer.
+        """Instantiate the Highway update layer.
 
         :param input_size: Current representation size.
         :param prev_input_size: Size of the representation obtained by the previous convolutional layer.
         """
-        super(Highway, self).__init__()
+        super().__init__()
         total_size = input_size + prev_input_size
         self.proj = nn.Linear(total_size, input_size)
         self.transform = nn.Linear(total_size, input_size)
         self.transform.bias.data.fill_(-2.0)
 
-    def forward(self, input: torch.Tensor, prev_input: torch.Tensor) -> torch.Tensor:
-        """
-        Compute the gated update.
+    def forward(self, current: torch.Tensor, previous: torch.Tensor) -> torch.Tensor:
+        """Compute the gated update.
 
-        :param input: Current node representations.
-        :param prev_input: Previous layer node representations.
+        :param current: Current layer node representations.
+        :param previous: Previous layer node representations.
         :returns: The highway-updated inputs.
         """
-        concat_inputs = torch.cat((input, prev_input), 1)
+        concat_inputs = torch.cat((current, previous), 1)
         proj_result = F.relu(self.proj(concat_inputs))
         proj_gate = F.sigmoid(self.transform(concat_inputs))
-        gated = (proj_gate * proj_result) + ((1 - proj_gate) * input)
+        gated = (proj_gate * proj_result) + ((1 - proj_gate) * current)
         return gated
 
 
 class AttentionPooling(nn.Module):
-    """
-    The Attention pooling layer from [gcnbmp].
-
-    .. [gcnbmp] `GCN-BMP: Investigating graph representation learning for DDI prediction task
-       <https://www.sciencedirect.com/science/article/pii/S1046202320300608>`_
-    """
+    """The attention pooling layer from [chen2020]_."""
 
     def __init__(self, molecule_channels: int, hidden_channels: int):
-        """
-        Instantiate the Attention pooling layer.
+        """Instantiate the attention pooling layer.
 
         :param molecule_channels: Input node features.
         :param hidden_channels: Final node representation.
         """
         super(AttentionPooling, self).__init__()
         total_features_channels = molecule_channels + hidden_channels
-        self.lin = nn.Linear(
-            total_features_channels, hidden_channels
-        )  # weights here must be shared across all nodes according to the paper
+        # weights here must be shared across all nodes according to the paper
+        self.lin = nn.Linear(total_features_channels, hidden_channels)
         self.last_rep = nn.Linear(hidden_channels, hidden_channels)
 
     def forward(self, input_rep: torch.Tensor, final_rep: torch.Tensor, graph_index: torch.Tensor) -> torch.Tensor:
@@ -101,58 +92,52 @@ class AttentionPooling(nn.Module):
         :param graph_index: Node to graph readout index.
         :returns: Graph-level representation.
         """
-        att = torch.sigmoid(self.lin(torch.cat((input_rep, final_rep), 1)))
+        att = torch.sigmoid(self.lin(torch.cat((input_rep, final_rep), dim=1)))
         g = att.mul(self.last_rep(final_rep))
         g = scatter_add(g, graph_index, dim=0)
         return g
 
 
 class GCNBMPEncoder(nn.Module, core.Configurable):
-    """
-    The drug encoding backbone from [gcnbmp].
-
-    .. [gcnbmp] `GCN-BMP: Investigating graph representation learning for DDI prediction task
-       <https://www.sciencedirect.com/science/article/pii/S1046202320300608>`_
-
-    """
+    """The drug encoding backbone from [chen2020]_."""
 
     def __init__(
         self,
         input_dim: int,
-        hidden_dims: List[int],
-        num_relation: int,
+        hidden_dims: Union[int, List[int]],
+        num_relations: int,
         edge_input_dim: Optional[int] = None,
         batch_norm: Optional[bool] = False,
         activation: Optional[str] = "sigmoid",
     ):
-        """
-        Instantiate the GCN-BMP encoder.
+        """Instantiate the GCN-BMP encoder.
 
         :param input_dim: Input dimensions.
         :param hidden_dims: Hidden dimensions.
-        :param num_relation: Number of relations.
+        :param num_relations: Number of relations.
         :param edge_input_dim: Dimension of edge features.
         :param batch_norm: Apply batch normalization on nodes or not.
         :param activation: Activation function.
         """
-        super(GCNBMPEncoder, self).__init__()
-
-        if not isinstance(hidden_dims, Sequence):
+        super().__init__()
+        if isinstance(hidden_dims, int):
             hidden_dims = [hidden_dims]
         self.input_dim = input_dim
-        self.dims = [input_dim] + list(hidden_dims)
-        self.num_relation = num_relation
+        self.dims = [input_dim, *hidden_dims]
 
         self.layers = nn.ModuleList()
         for left_dim, right_dim in pairwise(self.dims):
-            self.layers.append(
-                layers.RelationalGraphConv(left_dim, right_dim, num_relation, edge_input_dim, batch_norm, activation)
+            self.layers.extend(
+                (
+                    layers.RelationalGraphConv(
+                        left_dim, right_dim, num_relations, edge_input_dim, batch_norm, activation
+                    ),
+                    Highway(right_dim, left_dim),
+                )
             )
-            self.layers.append(Highway(right_dim, left_dim))
 
     def forward(self, graph: torchdrug.data.graph.PackedGraph, input_node_features: torch.Tensor) -> dict:
-        """
-        Compute the node representations and the graph representation(s).
+        """Compute the node representations and the graph representation(s).
 
         :param graph: Batch of molecular graphs.
         :param input_node_features: Input node representations
@@ -191,8 +176,7 @@ class GCNBMP(Model):
         hidden_conv_layers: int = 1,
         out_channels: int = 1,
     ):
-        """
-        Instantiate the GCN-BMP model.
+        """Instantiate the GCN-BMP model.
 
         :param molecule_channels: The number of node-level features.
         :param num_relations: Number of edge types.
@@ -200,38 +184,34 @@ class GCNBMP(Model):
         :param hidden_conv_layers: The number of hidden layers in the encoder.
         :param out_channels: The number of output channels.
         """
-        super(GCNBMP, self).__init__()
+        super().__init__()
         self.graph_convolutions = GCNBMPEncoder(
             molecule_channels, [hidden_channels for _ in range(hidden_conv_layers)], num_relations
         )
 
         self.attention_readout = AttentionPooling(molecule_channels, hidden_channels)
 
-        self.final = torch.nn.Linear(hidden_channels, out_channels)
+        self.final = nn.Linear(hidden_channels, out_channels)
 
-    def unpack(self, batch: DrugPairBatch) -> Tuple[torchdrug.data.graph.PackedGraph, torchdrug.data.graph.PackedGraph]:
+    def unpack(self, batch: DrugPairBatch) -> Tuple[PackedGraph, PackedGraph]:
         """Return the left and right drugs PackedGraphs."""
         return (
             batch.drug_molecules_left,
             batch.drug_molecules_right,
         )
 
-    def encoder_pass(self, molecules: torchdrug.data.graph.PackedGraph) -> torch.FloatTensor:
+    def encoder_pass(self, molecules: PackedGraph) -> torch.FloatTensor:
         """
         Run a forward pass of the encoder layers.
 
-        :param molecules: The bacthed molecular graphs.
+        :param molecules: The batched molecular graphs.
         :returns: A matrix of molecular features
         """
         features = self.graph_convolutions(molecules, molecules.data_dict["node_feature"])["node_feature"]
         features = self.attention_readout(molecules.data_dict["node_feature"], features, molecules.node2graph)
         return features
 
-    def forward(
-        self,
-        molecules_left: torchdrug.data.graph.PackedGraph,
-        molecules_right: torchdrug.data.graph.PackedGraph,
-    ) -> torch.FloatTensor:
+    def forward(self, molecules_left: PackedGraph, molecules_right: PackedGraph) -> torch.FloatTensor:
         """
         Run a forward pass of the GCN-BMP model.
 

--- a/chemicalx/models/gcnbmp.py
+++ b/chemicalx/models/gcnbmp.py
@@ -210,8 +210,7 @@ class GCNBMP(Model):
             molecule_channels, [hidden_channels for i in range(hidden_conv_layers)], num_relations
         )
 
-        self.attention_readout_left = AttentionPooling(molecule_channels, hidden_channels)
-        self.attention_readout_right = AttentionPooling(molecule_channels, hidden_channels)
+        self.attention_readout = AttentionPooling(molecule_channels, hidden_channels)
 
         self.final = torch.nn.Linear(hidden_channels, out_channels)
 
@@ -241,10 +240,10 @@ class GCNBMP(Model):
             "node_feature"
         ]
 
-        features_left = self.attention_readout_left(
+        features_left = self.attention_readout(
             molecules_left.data_dict["node_feature"], features_left, molecules_left.node2graph
         )
-        features_right = self.attention_readout_right(
+        features_right = self.attention_readout(
             molecules_right.data_dict["node_feature"], features_right, molecules_right.node2graph
         )
 

--- a/chemicalx/models/gcnbmp.py
+++ b/chemicalx/models/gcnbmp.py
@@ -1,14 +1,151 @@
 """An implementation of the GCNBMP model."""
+import sys
 
-from .base import UnimplementedModel
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.fft import fft, ifft
+
+from torchdrug import layers
+from torchdrug.data import PackedGraph
+from torchdrug.layers import MeanReadout
+from torchdrug.models import GraphConvolutionalNetwork, RelationalGraphConvolutionalNetwork
+
+from torch_scatter import scatter_add
+
+from chemicalx.constants import TORCHDRUG_NODE_FEATURES
+from chemicalx.data import DrugPairBatch
+from chemicalx.models import Model
+
 
 __all__ = [
     "GCNBMP",
 ]
 
 
-class GCNBMP(UnimplementedModel):
-    """An implementation of the GCNBMP model.
+def circular_correlation(left_x, right_x):
+    """
+    Computes the circular correlation of two vectors a and b via their fast fourier transforms
+    In python code, ifft(np.conj(fft(a)) * fft(b)).real
+    :param left_x:
+    :param right_x:
+    (a - j * b) * (c + j * d) = (ac + bd) + j * (ad - bc)
+    :return:
+    """
+    left_x_cfft = torch.conj(fft(left_x))
+    right_x_fft = fft(right_x)
+    circ_corr = ifft(torch.mul(left_x_cfft, right_x_fft))
+
+    return circ_corr.real
+
+
+class Highway(nn.Module):  # The traditional one, not exactly the one from the GCN-BMP paper
+    def __init__(self, input_size):
+        super(Highway, self).__init__()
+        self.proj = nn.Linear(input_size, input_size)
+        self.transform = nn.Linear(input_size, input_size)
+        self.transform.bias.data.fill_(-2.0)
+
+    def forward(self, input):
+        proj_result = F.relu(self.proj(input))
+        proj_gate = F.sigmoid(self.transform(input))
+        gated = (proj_gate * proj_result) + ((1 - proj_gate) * input)
+        return gated
+
+
+class AttentionPooling(nn.Module):
+    def __init__(self, molecule_channels, hidden_channels):
+        super(AttentionPooling, self).__init__()
+        # Here we concatenate layer 0 with the final representation
+        total_features_channels = molecule_channels + hidden_channels
+        self.lin = nn.Linear(
+            total_features_channels, hidden_channels
+        )  # weights here must be shared across all nodes according to the paper
+        self.last_rep = nn.Linear(hidden_channels, hidden_channels)
+
+    def forward(self, input_rep, final_rep):
+        #        print("Input and Final representation shapes: ")
+        #        print(input_rep.shape, final_rep.shape)
+        att = torch.sigmoid(self.lin(torch.cat((input_rep, final_rep), 1)))  # .mul(input)
+        #        print("Attention shape", att.shape)
+        g = att.mul(self.last_rep(final_rep))
+        g = torch.sum(g, dim=0)
+        print("g shape: ", g.shape)
+        print("g after sum",)
+
+        return g
+
+
+class GCNBMP(Model):
+    r"""An implementation of the GCNBMP model.
 
     .. seealso:: https://github.com/AstraZeneca/chemicalx/issues/21
     """
+
+    def __init__(
+        self,
+        *,
+        molecule_channels: int = TORCHDRUG_NODE_FEATURES,
+        hidden_channels: int = 16,
+        hidden_conv_layers: int = 1,
+        out_channels: int = 1,
+    ):
+        super(GCNBMP, self).__init__()
+
+        self.graph_convolution_in = RelationalGraphConvolutionalNetwork(molecule_channels, hidden_channels, 4)
+        self.highway = Highway(hidden_channels)
+
+        self.encoding_backbone = nn.ModuleList()
+
+        for i in range(hidden_conv_layers):
+            self.encoding_backbone.append(RelationalGraphConvolutionalNetwork(hidden_channels, hidden_channels, 4))
+            self.encoding_backbone.append(Highway(hidden_channels))
+
+        self.attention_readout_left = AttentionPooling(molecule_channels, hidden_channels)
+        self.attention_readout_right = AttentionPooling(molecule_channels, hidden_channels)
+
+        self.final = torch.nn.Linear(hidden_channels, out_channels)
+
+    def unpack(self, batch: DrugPairBatch):
+        """Return the context features, left drug features, and right drug features."""
+        return (
+            batch.drug_molecules_left,
+            batch.drug_molecules_right,
+        )
+
+    def forward(self, molecules_left: torch.FloatTensor, molecules_right: torch.FloatTensor,) -> torch.FloatTensor:
+        print(molecules_left.shape)
+        print(molecules_right.shape)
+
+        print(molecules_left.data_dict["node_feature"].shape, molecules_right.data_dict["node_feature"].shape)
+
+        features_left = self.graph_convolution_in(molecules_left, molecules_left.data_dict["node_feature"])[
+            "node_feature"
+        ]
+
+        features_right = self.graph_convolution_in(molecules_right, molecules_right.data_dict["node_feature"])[
+            "node_feature"
+        ]
+
+        print(features_left.shape, features_right.shape)
+
+        # for i,l in enumerate(self.encoding_backbone):
+        #    print(i, l)
+
+        features_left = self.attention_readout_left(molecules_left.data_dict["node_feature"], features_left)
+        features_right = self.attention_readout_right(molecules_right.data_dict["node_feature"], features_right)
+
+        print(features_left.shape, features_right.shape)
+
+        joint_rep = circular_correlation(features_left, features_right)
+
+        print(joint_rep.shape)
+
+        # features_left = self.graph_convolution_out(molecules_left, features_left)["node_feature"]
+        # features_right = self.graph_convolution_out(molecules_right, features_right)["node_feature"]
+
+        # features_left = self.mean_readout(molecules_left, features_left)
+        # features_right = self.mean_readout(molecules_right, features_right)
+        # hidden = features_left + features_right
+        hidden = torch.sigmoid(self.final(joint_rep))
+        return hidden

--- a/chemicalx/models/gcnbmp.py
+++ b/chemicalx/models/gcnbmp.py
@@ -21,7 +21,7 @@ __all__ = [
 ]
 
 
-def circular_correlation(left_x, right_x):
+def circular_correlation(left_x: torch.FloatTensor, right_x: torch.FloatTensor) -> torch.FloatTensor:
     """
     Computes the circular correlation of two vectors a and b via their fast fourier transforms
     In python code, ifft(np.conj(fft(a)) * fft(b)).real
@@ -184,9 +184,10 @@ class GCNBMPEncoder(nn.Module, core.Configurable):
 
 
 class GCNBMP(Model):
-    r"""An implementation of the GCNBMP model.
+    r"""The GCNBMP model from [gcnbmp].
 
-    .. seealso:: https://github.com/AstraZeneca/chemicalx/issues/21
+    .. [gcnbmp] `GCN-BMP: Investigating graph representation learning for DDI prediction task
+       <https://www.sciencedirect.com/science/article/pii/S1046202320300608>`_
     """
 
     def __init__(

--- a/chemicalx/models/gcnbmp.py
+++ b/chemicalx/models/gcnbmp.py
@@ -189,10 +189,12 @@ class GCNBMPEncoder(nn.Module, core.Configurable):
 
 
 class GCNBMP(Model):
-    r"""The GCNBMP model from [gcnbmp].
+    """An implementation of the GCN-BMP model from [chen2020]_.
 
-    .. [gcnbmp] `GCN-BMP: Investigating graph representation learning for DDI prediction task
-       <https://www.sciencedirect.com/science/article/pii/S1046202320300608>`_
+    .. seealso:: This model was suggested in https://github.com/AstraZeneca/chemicalx/issues/21
+    
+    .. [chen2020] Chen, X., *et al.* (2020). `GCN-BMP: Investigating graph representation learning
+       for DDI prediction task <https://doi.org/10.1016/j.ymeth.2020.05.014>`_. *Methods*, 179, 47–54.
     """
 
     def __init__(

--- a/chemicalx/models/gcnbmp.py
+++ b/chemicalx/models/gcnbmp.py
@@ -175,7 +175,9 @@ class GCNBMPEncoder(nn.Module, core.Configurable):
 
 class GCNBMP(Model):
     """An implementation of the GCN-BMP model from [chen2020]_.
+
     .. seealso:: This model was suggested in https://github.com/AstraZeneca/chemicalx/issues/21
+
     .. [chen2020] Chen, X., *et al.* (2020). `GCN-BMP: Investigating graph representation learning
        for DDI prediction task <https://doi.org/10.1016/j.ymeth.2020.05.014>`_. *Methods*, 179, 47–54.
     """

--- a/chemicalx/models/gcnbmp.py
+++ b/chemicalx/models/gcnbmp.py
@@ -19,19 +19,18 @@ __all__ = [
     "GCNBMP",
 ]
 
+
 def circular_correlation(left_x: torch.FloatTensor, right_x: torch.FloatTensor) -> torch.FloatTensor:
     """
     Compute the circular correlation of two vectors a and b via their fast fourier transforms.
 
-    In python code, ifft(np.conj(fft(a)) * fft(b)).real
-    :param left_x: representation of the left molecule.
-    :param right_x: representation of the right molecule.
-    :return circ_corr.real: joint representation by circular correlation.
+    :param left_x: Molecular representations on the left.
+    :param right_x: Molecular representations on the right.
+    :returns: Joint representation by circular correlation.
     """
     left_x_cfft = torch.conj(fft(left_x))
     right_x_fft = fft(right_x)
     circ_corr = ifft(torch.mul(left_x_cfft, right_x_fft))
-
     return circ_corr.real
 
 
@@ -47,26 +46,22 @@ class Highway(nn.Module):
         """
         Instantiate the Highway update layer.
 
-        :param input_size: current representation size.
-        :param prev_input_size: size of the representation obtained by the previous convolutional layer.
+        :param input_size: Current representation size.
+        :param prev_input_size: Size of the representation obtained by the previous convolutional layer.
         """
         super(Highway, self).__init__()
         total_size = input_size + prev_input_size
         self.proj = nn.Linear(total_size, input_size)
         self.transform = nn.Linear(total_size, input_size)
-        # Not in GCN-BMP paper but present in the original implementation
         self.transform.bias.data.fill_(-2.0)
 
     def forward(self, input: torch.Tensor, prev_input: torch.Tensor) -> torch.Tensor:
         """
         Compute the gated update.
 
-        Parameters:
-            input: Current node representations.
-            prev_input: Previous layer node representation.
-
-        Returns:
-            gated: the highway-updated inputs
+        :param input: Current node representations.
+        :param prev_input: Previous layer node representations.
+        :returns: The highway-updated inputs.
         """
         concat_inputs = torch.cat((input, prev_input), 1)
         proj_result = F.relu(self.proj(concat_inputs))
@@ -87,8 +82,8 @@ class AttentionPooling(nn.Module):
         """
         Instantiate the Attention pooling layer.
 
-        :param molecules_channels: input node features (layer 0 of the backbone).
-        :param hidden_channels: final node representation (layer L of the backbone).
+        :param molecule_channels: Input node features.
+        :param hidden_channels: Final node representation.
         """
         super(AttentionPooling, self).__init__()
         total_features_channels = molecule_channels + hidden_channels
@@ -101,13 +96,10 @@ class AttentionPooling(nn.Module):
         """
         Compute an attention-based readout using the input and output layers of the RGCN encoder for one molecule.
 
-        Parameters:
-            input_rep: input nodes representations
-            final_rep: final nodes representations
-            graph_index: node to graph readout index
-
-        Returns:
-            g: graph-level representation
+        :param input_rep: Input nodes representations.
+        :param final_rep: Final nodes representations.
+        :param graph_index: Node to graph readout index.
+        :returns: Graph-level representation.
         """
         att = torch.sigmoid(self.lin(torch.cat((input_rep, final_rep), 1)))
         g = att.mul(self.last_rep(final_rep))
@@ -136,12 +128,12 @@ class GCNBMPEncoder(nn.Module, core.Configurable):
         """
         Instantiate the GCN-BMP encoder.
 
-        :param input_dim: input dimension.
-        :param hidden_dims: hidden dimensions.
-        :param num_relation: number of relations.
-        :param edge_input_dim: dimension of edge features.
-        :param batch_norm: apply batch normalization on nodes or not.
-        :param activation: activation function.
+        :param input_dim: Input dimensions.
+        :param hidden_dims: Hidden dimensions.
+        :param num_relation: Number of relations.
+        :param edge_input_dim: Dimension of edge features.
+        :param batch_norm: Apply batch normalization on nodes or not.
+        :param activation: Activation function.
         """
         super(GCNBMPEncoder, self).__init__()
 
@@ -158,23 +150,17 @@ class GCNBMPEncoder(nn.Module, core.Configurable):
             )
             self.layers.append(Highway(right_dim, left_dim))
 
-    def forward(self, graph: torchdrug.data.graph.PackedGraph, input: torch.Tensor) -> dict:
+    def forward(self, graph: torchdrug.data.graph.PackedGraph, input_node_features: torch.Tensor) -> dict:
         """
         Compute the node representations and the graph representation(s).
 
-        Require the graph(s) to have the same number of relations as this module.
-
-        Parameters:
-            graph: :math:`n` graph(s)
-            input: input node representations
-
-        Returns:
-            dict with ``node_feature`` field:
-                node representations of shape :math:`(|V|, d)`
+        :param graph: Batch of molecular graphs.
+        :param input_node_features: Input node representations
+        :returns: Node representation matrix.
         """
         hiddens = []
-        layer_input = input
-        prev_gcn = input
+        layer_input = input_node_features
+        prev_gcn = input_node_features
 
         for conv, highway in chunked(self.layers, 2):
             hidden = conv(graph, layer_input)
@@ -183,16 +169,14 @@ class GCNBMPEncoder(nn.Module, core.Configurable):
             hiddens.append(hidden)
             layer_input = hidden
             prev_gcn = hiddens[-2]
-
         node_feature = hiddens[-1]
         return {"node_feature": node_feature}
 
 
 class GCNBMP(Model):
     """An implementation of the GCN-BMP model from [chen2020]_.
-
     .. seealso:: This model was suggested in https://github.com/AstraZeneca/chemicalx/issues/21
-    
+
     .. [chen2020] Chen, X., *et al.* (2020). `GCN-BMP: Investigating graph representation learning
        for DDI prediction task <https://doi.org/10.1016/j.ymeth.2020.05.014>`_. *Methods*, 179, 47–54.
     """
@@ -210,14 +194,14 @@ class GCNBMP(Model):
         Instantiate the GCN-BMP model.
 
         :param molecule_channels: The number of node-level features.
+        :param num_relations: Number of edge types.
         :param hidden_channels: The number of hidden layer neurons in the input layer.
         :param hidden_conv_layers: The number of hidden layers in the encoder.
         :param out_channels: The number of output channels.
         """
         super(GCNBMP, self).__init__()
-
         self.graph_convolutions = GCNBMPEncoder(
-            molecule_channels, [hidden_channels for i in range(hidden_conv_layers)], num_relations
+            molecule_channels, [hidden_channels for _ in range(hidden_conv_layers)], num_relations
         )
 
         self.attention_readout = AttentionPooling(molecule_channels, hidden_channels)
@@ -231,35 +215,31 @@ class GCNBMP(Model):
             batch.drug_molecules_right,
         )
 
+    def encoder_pass(self, molecules: torchdrug.data.graph.PackedGraph) -> torch.FloatTensor:
+        """
+        Run a forward pass of the encoder layers.
+
+        :param molecules: The bacthed molecular graphs.
+        :returns: A matrix of molecular features
+        """
+        features = self.graph_convolutions(molecules, molecules.data_dict["node_feature"])["node_feature"]
+        features = self.attention_readout(molecules.data_dict["node_feature"], features, molecules.node2graph)
+        return features
+
     def forward(
-        self, molecules_left: torchdrug.data.graph.PackedGraph, molecules_right: torchdrug.data.graph.PackedGraph,
+        self,
+        molecules_left: torchdrug.data.graph.PackedGraph,
+        molecules_right: torchdrug.data.graph.PackedGraph,
     ) -> torch.FloatTensor:
         """
         Run a forward pass of the GCN-BMP model.
 
-        Args:
-            molecules_left: The graph of left drug and node features.
-            molecules_right: The graph of right drug and node features.
-        Returns:
-            hidden: A column vector of predicted synergy scores.
+        :param molecules_left: The graph of left drug and node features.
+        :param molecules_right: The graph of right drug and node features.
+        :returns: A column vector of predicted synergy scores.
         """
-        features_left = self.graph_convolutions(molecules_left, molecules_left.data_dict["node_feature"])[
-            "node_feature"
-        ]
-
-        features_right = self.graph_convolutions(molecules_right, molecules_right.data_dict["node_feature"])[
-            "node_feature"
-        ]
-
-        features_left = self.attention_readout(
-            molecules_left.data_dict["node_feature"], features_left, molecules_left.node2graph
-        )
-        features_right = self.attention_readout(
-            molecules_right.data_dict["node_feature"], features_right, molecules_right.node2graph
-        )
-
+        features_left = self.encoder_pass(molecules_left)
+        features_right = self.encoder_pass(molecules_right)
         joint_rep = circular_correlation(features_left, features_right)
-
         interaction_estimators = torch.sigmoid(self.final(joint_rep))
-
         return interaction_estimators

--- a/chemicalx/models/gcnbmp.py
+++ b/chemicalx/models/gcnbmp.py
@@ -2,7 +2,7 @@
 from collections.abc import Sequence
 from typing import Tuple, Optional
 
-from more_itertools import chunked
+from more_itertools import chunked, pairwise
 
 import torch
 import torch.nn as nn
@@ -129,13 +129,13 @@ class GCNBMPEncoder(nn.Module, core.Configurable):
         self.num_relation = num_relation
 
         self.layers = nn.ModuleList()
-        for i in range(len(self.dims) - 1):
+        for left_dim, right_dim in pairwise(self.dims):
             self.layers.append(
                 layers.RelationalGraphConv(
-                    self.dims[i], self.dims[i + 1], num_relation, edge_input_dim, batch_norm, activation
+                    left_dim, right_dim, num_relation, edge_input_dim, batch_norm, activation
                 )
             )
-            self.layers.append(Highway(self.dims[i + 1], self.dims[i]))
+            self.layers.append(Highway(right_dim, left_dim))
 
     def forward(self, graph: torchdrug.data.graph.PackedGraph, input: torch.Tensor) -> dict:
         """

--- a/chemicalx/models/gcnbmp.py
+++ b/chemicalx/models/gcnbmp.py
@@ -176,7 +176,6 @@ class GCNBMPEncoder(nn.Module, core.Configurable):
 class GCNBMP(Model):
     """An implementation of the GCN-BMP model from [chen2020]_.
     .. seealso:: This model was suggested in https://github.com/AstraZeneca/chemicalx/issues/21
-
     .. [chen2020] Chen, X., *et al.* (2020). `GCN-BMP: Investigating graph representation learning
        for DDI prediction task <https://doi.org/10.1016/j.ymeth.2020.05.014>`_. *Methods*, 179, 47–54.
     """

--- a/chemicalx/models/gcnbmp.py
+++ b/chemicalx/models/gcnbmp.py
@@ -1,23 +1,19 @@
 """An implementation of the GCNBMP model."""
 from collections.abc import Sequence
-from typing import Tuple, Optional
-
-from more_itertools import chunked, pairwise
+from typing import List, Optional, Tuple
 
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
-from torch.fft import fft, ifft
-
+import torch.nn.functional as F  # noqa:N812
 import torchdrug
-from torchdrug import layers, core
-
+from more_itertools import chunked, pairwise
+from torch.fft import fft, ifft
 from torch_scatter import scatter_add
+from torchdrug import core, layers
 
 from chemicalx.constants import TORCHDRUG_NODE_FEATURES
 from chemicalx.data import DrugPairBatch
 from chemicalx.models import Model
-
 
 __all__ = [
     "GCNBMP",
@@ -26,7 +22,8 @@ __all__ = [
 
 def circular_correlation(left_x: torch.FloatTensor, right_x: torch.FloatTensor) -> torch.FloatTensor:
     """
-    Computes the circular correlation of two vectors a and b via their fast fourier transforms
+    Compute the circular correlation of two vectors a and b via their fast fourier transforms.
+
     In python code, ifft(np.conj(fft(a)) * fft(b)).real
     :param left_x: representation of the left molecule.
     :param right_x: representation of the right molecule.
@@ -48,7 +45,9 @@ class Highway(nn.Module):
     """
 
     def __init__(self, input_size: int, prev_input_size: int):
-        """Instantiate the Highway update layer
+        """
+        Instantiate the Highway update layer.
+
         :param input_size: current representation size.
         :param prev_input_size: size of the representation obtained by the previous convolutional layer.
         """
@@ -61,7 +60,7 @@ class Highway(nn.Module):
 
     def forward(self, input: torch.Tensor, prev_input: torch.Tensor) -> torch.Tensor:
         """
-        Compute the gated update
+        Compute the gated update.
 
         Parameters:
             input: Current node representations.
@@ -86,7 +85,9 @@ class AttentionPooling(nn.Module):
     """
 
     def __init__(self, molecule_channels: int, hidden_channels: int):
-        """Instantiate the Attention pooling layer
+        """
+        Instantiate the Attention pooling layer.
+
         :param molecules_channels: input node features (layer 0 of the backbone).
         :param hidden_channels: final node representation (layer L of the backbone).
         """
@@ -99,8 +100,7 @@ class AttentionPooling(nn.Module):
 
     def forward(self, input_rep: torch.Tensor, final_rep: torch.Tensor, graph_index: torch.Tensor) -> torch.Tensor:
         """
-        Compute an attention-based readout using the input and output layers of the 
-        RGCN encoder for one molecule.
+        Compute an attention-based readout using the input and output layers of the RGCN encoder for one molecule.
 
         Parameters:
             input_rep: input nodes representations
@@ -127,13 +127,15 @@ class GCNBMPEncoder(nn.Module, core.Configurable):
     def __init__(
         self,
         input_dim: int,
-        hidden_dims: int,
+        hidden_dims: List[int],
         num_relation: int,
         edge_input_dim: Optional[int] = None,
         batch_norm: Optional[bool] = False,
         activation: Optional[str] = "sigmoid",
     ):
-        """Instantiate the GCN-BMP encoder.
+        """
+        Instantiate the GCN-BMP encoder.
+
         :param input_dim: input dimension.
         :param hidden_dims: hidden dimensions.
         :param num_relation: number of relations.
@@ -202,7 +204,9 @@ class GCNBMP(Model):
         hidden_conv_layers: int = 1,
         out_channels: int = 1,
     ):
-        """Instantiate the GCN-BMP model.
+        """
+        Instantiate the GCN-BMP model.
+
         :param molecule_channels: The number of node-level features.
         :param hidden_channels: The number of hidden layer neurons in the input layer.
         :param hidden_conv_layers: The number of hidden layers in the encoder.
@@ -230,6 +234,7 @@ class GCNBMP(Model):
     ) -> torch.FloatTensor:
         """
         Run a forward pass of the GCN-BMP model.
+
         Args:
             molecules_left: The graph of left drug and node features.
             molecules_right: The graph of right drug and node features.

--- a/chemicalx/models/gcnbmp.py
+++ b/chemicalx/models/gcnbmp.py
@@ -1,5 +1,4 @@
 """An implementation of the GCNBMP model."""
-import sys
 from collections.abc import Sequence
 
 import torch
@@ -9,7 +8,6 @@ from torch.fft import fft, ifft
 
 import torchdrug
 from torchdrug import layers, core
-from torchdrug.models import RelationalGraphConvolutionalNetwork
 
 from torch_scatter import scatter_add
 

--- a/examples/gcnbmp_examples.py
+++ b/examples/gcnbmp_examples.py
@@ -8,7 +8,7 @@ from chemicalx.models import GCNBMP
 def main():
     """Train and evaluate the EPGCNDS model."""
     dataset = DrugCombDB()
-    model = GCNBMP(hidden_conv_layers=0)
+    model = GCNBMP(hidden_conv_layers=1)
 
     print(model)
 
@@ -16,7 +16,7 @@ def main():
         dataset=dataset,
         model=model,
         optimizer_kwargs=dict(lr=0.01, weight_decay=10 ** -7),
-        batch_size=3,
+        batch_size=5,
         epochs=1,
         context_features=True,
         drug_features=True,

--- a/examples/gcnbmp_examples.py
+++ b/examples/gcnbmp_examples.py
@@ -1,0 +1,29 @@
+"""Example with EPGCNDS."""
+
+from chemicalx import pipeline
+from chemicalx.data import DrugCombDB
+from chemicalx.models import GCNBMP
+
+
+def main():
+    """Train and evaluate the EPGCNDS model."""
+    dataset = DrugCombDB()
+    model = GCNBMP(hidden_conv_layers=0)
+
+    print(model)
+
+    results = pipeline(
+        dataset=dataset,
+        model=model,
+        optimizer_kwargs=dict(lr=0.01, weight_decay=10 ** -7),
+        batch_size=3,
+        epochs=1,
+        context_features=True,
+        drug_features=True,
+        drug_molecules=True,
+    )
+    results.summarize()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/gcnbmp_examples.py
+++ b/examples/gcnbmp_examples.py
@@ -13,7 +13,7 @@ def main():
     results = pipeline(
         dataset=dataset,
         model=model,
-        optimizer_kwargs=dict(lr=0.01, weight_decay=10 ** -7),
+        optimizer_kwargs=dict(lr=0.01, weight_decay=10**-7),
         batch_size=5120,
         epochs=100,
         context_features=True,

--- a/examples/gcnbmp_examples.py
+++ b/examples/gcnbmp_examples.py
@@ -1,4 +1,4 @@
-"""Example with EPGCNDS."""
+"""Example with GCNBMP."""
 
 from chemicalx import pipeline
 from chemicalx.data import DrugCombDB
@@ -6,7 +6,7 @@ from chemicalx.models import GCNBMP
 
 
 def main():
-    """Train and evaluate the EPGCNDS model."""
+    """Train and evaluate the GCNBMP model."""
     dataset = DrugCombDB()
     model = GCNBMP(hidden_conv_layers=2)
 

--- a/examples/gcnbmp_examples.py
+++ b/examples/gcnbmp_examples.py
@@ -8,16 +8,14 @@ from chemicalx.models import GCNBMP
 def main():
     """Train and evaluate the EPGCNDS model."""
     dataset = DrugCombDB()
-    model = GCNBMP(hidden_conv_layers=1)
-
-    print(model)
+    model = GCNBMP(hidden_conv_layers=2)
 
     results = pipeline(
         dataset=dataset,
         model=model,
         optimizer_kwargs=dict(lr=0.01, weight_decay=10 ** -7),
-        batch_size=5,
-        epochs=1,
+        batch_size=5120,
+        epochs=100,
         context_features=True,
         drug_features=True,
         drug_molecules=True,

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ install_requires = [
     "tabulate",
     "pystow",
     "pytdc",
-    "more-itertools"
+    "more-itertools",
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ install_requires = [
     "tabulate",
     "pystow",
     "pytdc",
+    "more-itertools"
 ]
 
 

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -173,8 +173,18 @@ class TestModels(unittest.TestCase):
 
     def test_gcnbmp(self):
         """Test GCNBMP."""
-        model = GCNBMP(x=2)
-        assert model.x == 2
+        model = GCNBMP()
+
+        optimizer = torch.optim.Adam(model.parameters(), lr=0.01, weight_decay=0.0001)
+        model.train()
+        loss = torch.nn.BCELoss()
+        for batch in self.generator:
+            optimizer.zero_grad()
+            prediction = model(batch.drug_molecules_left, batch.drug_molecules_right)
+            output = loss(prediction, batch.labels)
+            output.backward()
+            optimizer.step()
+            assert prediction.shape[0] == batch.labels.shape[0]
 
     def test_mhcaddi(self):
         """Test MHCADDI."""


### PR DESCRIPTION
# Summary
 
First draft of implementation for GCN-BMP. Closes Issue #21 .

- [ ] Unit tests provided for these changes
- [x] Documentation and docstrings added for these changes

## Changes 

* Add GCN-BMP model. Some parts might be moved in other files/projects:
   - Circular correlation function.
   - Highway update
   - Attention-based pooling/readout
* Add example for the model.

## Caveats
* The number of relationships (for the Relational Conv layers) is configured in the model initialization. It should be done via some dataset-level constant.

## Differences with the original paper
* In the original GCN-BMP the feature vectors are initialized randomly based on the atomic number of the node. I couldn't find easily the implementation in their code so backed up on the features already provided in the PairedBatches.
* Rel Conv layers are followed by a sigmoid activation before the Highway Update. This should only affect the stability.
* Highway Update used is the one proposed in the original Highway network paper. Best for reusability imho and shouldn't affect the gating behavour.

## Performance
Example's ROC AUC: 0.749128
