### PR TITLE
Move back the BatchGenerator to the data namespace.

### DIFF
--- a/chemicalx/data/__init__.py
+++ b/chemicalx/data/__init__.py
@@ -2,6 +2,7 @@
 
 from class_resolver import Resolver
 
+from .batchgenerator import BatchGenerator
 from .contextfeatureset import ContextFeatureSet
 from .datasetloader import (
     DatasetLoader,
@@ -18,6 +19,7 @@ from .drugpairbatch import DrugPairBatch
 from .labeledtriples import LabeledTriples
 
 __all__ = [
+    "BatchGenerator",
     "ContextFeatureSet",
     "DrugFeatureSet",
     "DrugPairBatch",


### PR DESCRIPTION

# Summary
 
The batch generator is back on the main namespace.
 
- [x] Unit tests provided for these changes
- [x] Documentation and docstrings added for these changes using the [sphinx style](https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html)

## Changes 

* BatchGenerator is back on the data name space for direct imports.
