### PR TITLE
Change DeepDDS and CASTER defaults and remove DeepDDS Softmax bug

### DIFF
--- a/chemicalx/models/caster.py
+++ b/chemicalx/models/caster.py
@@ -26,10 +26,11 @@ class CASTER(Model):
         self,
         *,
         drug_channels: int,
-        encoder_hidden_channels: int = 500,
-        encoder_output_channels: int = 50,
-        decoder_hidden_channels: int = 500,
-        hidden_channels: int = 1024,
+        encoder_hidden_channels: int = 32,
+        encoder_output_channels: int = 32,
+        decoder_hidden_channels: int = 32,
+        hidden_channels: int = 32,
+        out_hidden_channels: int = 32,
         out_channels: int = 1,
         lambda3: float = 1e-5,
         magnifying_factor: int = 100,
@@ -42,6 +43,7 @@ class CASTER(Model):
         :param encoder_output_channels: The number of output layer neurons in the encoder module.
         :param decoder_hidden_channels: The number of hidden layer neurons in the decoder module.
         :param hidden_channels: The number of hidden layer neurons in the predictor module.
+        :param out_hidden_channels: The last hidden layer channels before output.
         :param out_channels: The number of output channels.
         :param lambda3: regularisation coefficient in the dictionary encoder module.
         :param magnifying_factor: The magnifying factor coefficient applied to the predictor module input.
@@ -74,10 +76,9 @@ class CASTER(Model):
             if i < 5:
                 predictor_layers.append(torch.nn.Linear(hidden_channels, hidden_channels))
             else:
-                # in the original paper, the output of the last hidden layer before the output was fixed at 64 channels
-                predictor_layers.append(torch.nn.Linear(hidden_channels, 64))
+                predictor_layers.append(torch.nn.Linear(hidden_channels, out_hidden_channels))
             predictor_layers.append(torch.nn.ReLU(True))
-        predictor_layers.append(torch.nn.Linear(64, out_channels))
+        predictor_layers.append(torch.nn.Linear(out_hidden_channels, out_channels))
         predictor_layers.append(torch.nn.Sigmoid())
         self.predictor = torch.nn.Sequential(*predictor_layers)
 

--- a/chemicalx/models/deepdds.py
+++ b/chemicalx/models/deepdds.py
@@ -61,9 +61,9 @@ class DeepDDS(Model):
         drug_channels: int = TORCHDRUG_NODE_FEATURES,
         drug_gcn_hidden_dims: Optional[List[int]] = None,
         drug_mlp_hidden_dims: Optional[List[int]] = None,
-        context_output_size: int = 128,
+        context_output_size: int = 32,
         fc_hidden_dims: Optional[List[int]] = None,
-        dropout: float = 0.2,  # Rate used in paper
+        dropout: float = 0.5,  # Different from rate used in paper
     ):
         """Instantiate the DeepDDS model.
 
@@ -71,7 +71,7 @@ class DeepDDS(Model):
             The size of the context feature embedding for cell lines.
         :param context_hidden_dims:
             The hidden dimensions of the MLP used to extract the context
-            feature embedding. Default: [512, 256]. Note: the last layer
+            feature embedding. Default: [32, 32]. Note: the last layer
             will always be of size=context_output_size and appended to the
             provided list.
         :param drug_channels:
@@ -92,7 +92,7 @@ class DeepDDS(Model):
             connected layers.
         :param fc_hidden_dims:
             The hidden dimensions of the final fully connected layers.
-            Default: [512, 128]. Note: the last layer will always be of
+            Default: [32, 32]. Note: the last layer will always be of
             size=1 (the synergy prediction readout) and appended to the
             provided list.
         :param dropout:
@@ -101,21 +101,22 @@ class DeepDDS(Model):
         """
         super().__init__()
         # Check default parameters:
-        # Defaults follow the code implementation
+        # Defaults are different from the original implementation.
         if context_hidden_dims is None:
-            context_hidden_dims = [512, 256]
+            context_hidden_dims = [32, 32]
         if drug_gcn_hidden_dims is None:
             drug_gcn_hidden_dims = [drug_channels, drug_channels * 2, drug_channels * 4]
         if drug_mlp_hidden_dims is None:
             drug_mlp_hidden_dims = [drug_channels * 2]
         if fc_hidden_dims is None:
-            fc_hidden_dims = [512, 128]
+            fc_hidden_dims = [32, 32]
 
         # Cell feature extraction with MLP
         self.cell_mlp = MLP(
             input_dim=context_channels,
             # Paper: [2048, 512, context_output_size]
             # Code: [512, 256, context_output_size]
+            # Our code: [32, 32, context_output_size]
             hidden_dims=[*context_hidden_dims, context_output_size],
         )
 
@@ -143,13 +144,10 @@ class DeepDDS(Model):
         self.final = nn.Sequential(
             MLP(
                 input_dim=context_output_size * 3,
-                # Paper: [1024, 512, 128, 1]
-                # Code: [512, 128, 2]
-                # Following code except for one final neuron instead of two.
                 hidden_dims=[*fc_hidden_dims, 1],
                 dropout=dropout,
             ),
-            nn.Softmax(dim=1),
+            torch.nn.Sigmoid(),
         )
 
     def unpack(self, batch: DrugPairBatch):


### PR DESCRIPTION

# Summary

Changing the DeepDDS and CASTER default hyperparamters. Also fixes a minor bug. 

- [x] Unit tests provided for these changes
- [x] Documentation and docstrings added for these changes using the [sphinx style](https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html)

## Changes 

* Removes the softmax bug.
* Removes CASTER hardcoded hyperparameters.
* Changes the default hyperparameters to be aligned with ChemX paper.
* This also reduces the compute time on CI/CD.
