### PR TITLE
Add compatibility layer for `PackedGraph`

### DIFF
--- a/chemicalx/compat.py
+++ b/chemicalx/compat.py
@@ -1,4 +1,4 @@
-"""A compatibility layer for chemcialx."""
+"""A compatibility layer for chemicalx."""
 
 import torch
 import torchdrug.data

--- a/chemicalx/compat.py
+++ b/chemicalx/compat.py
@@ -1,0 +1,36 @@
+"""A compatibility layer for chemcialx."""
+
+import torch
+import torchdrug.data
+from torch.types import Device
+
+__all__ = [
+    "PackedGraph",
+]
+
+
+class PackedGraph(torchdrug.data.PackedGraph):
+    """A compatibility later that implements a to() function.
+
+    This can be removed when https://github.com/DeepGraphLearning/torchdrug/pull/70
+    is merged and a new version of torchdrug is released.
+    """
+
+    def to(self, device: Device):
+        """Return a copy of this packed graph on the given device."""
+        if isinstance(device, str):
+            if device == "cpu":
+                return self.cpu()
+            elif device == "cuda":
+                return self.cuda()
+            else:
+                raise NotImplementedError(f"{self.__class__.__name__}.to() is not implemented for string: {device}")
+        elif isinstance(device, torch.device):
+            if device.type == "cpu":
+                return self.cpu()
+            elif device.type == "cuda":
+                return self.cuda()
+            else:
+                raise NotImplementedError
+        else:
+            raise TypeError

--- a/chemicalx/compat.py
+++ b/chemicalx/compat.py
@@ -6,6 +6,7 @@ from torch.types import Device
 
 __all__ = [
     "PackedGraph",
+    "Graph",
 ]
 
 
@@ -34,3 +35,9 @@ class PackedGraph(torchdrug.data.PackedGraph):
                 raise NotImplementedError
         else:
             raise TypeError
+
+
+class Graph(torchdrug.data.Graph):
+    """A compatibility layer that makes appropriate packed graphs."""
+
+    packed_type = PackedGraph

--- a/chemicalx/data/batchgenerator.py
+++ b/chemicalx/data/batchgenerator.py
@@ -7,11 +7,11 @@ import numpy as np
 import pandas as pd
 import torch
 
-from .compat import PackedGraph
 from .contextfeatureset import ContextFeatureSet
 from .drugfeatureset import DrugFeatureSet
 from .drugpairbatch import DrugPairBatch
 from .labeledtriples import LabeledTriples
+from ..compat import PackedGraph
 
 __all__ = [
     "BatchGenerator",

--- a/chemicalx/data/batchgenerator.py
+++ b/chemicalx/data/batchgenerator.py
@@ -6,8 +6,8 @@ from typing import Iterable, Iterator, Optional, Sequence
 import numpy as np
 import pandas as pd
 import torch
-from torchdrug.data import PackedGraph
 
+from .compat import PackedGraph
 from .contextfeatureset import ContextFeatureSet
 from .drugfeatureset import DrugFeatureSet
 from .drugpairbatch import DrugPairBatch

--- a/chemicalx/data/drugfeatureset.py
+++ b/chemicalx/data/drugfeatureset.py
@@ -4,7 +4,9 @@ from collections import UserDict
 from typing import Dict, Iterable, Mapping, Union
 
 import torch
-from torchdrug.data import Graph, Molecule, PackedGraph
+from torchdrug.data import Graph, Molecule
+
+from chemicalx.compat import PackedGraph
 
 __all__ = [
     "DrugFeatureSet",
@@ -41,4 +43,5 @@ class DrugFeatureSet(UserDict, Mapping[str, Mapping[str, Union[torch.FloatTensor
         :param drugs: A list of drug identifiers.
         :returns: The molecules batched together for message passing.
         """
+        # TODO hack this
         return Graph.pack([self.data[drug]["molecule"] for drug in drugs])

--- a/chemicalx/data/drugfeatureset.py
+++ b/chemicalx/data/drugfeatureset.py
@@ -4,9 +4,9 @@ from collections import UserDict
 from typing import Dict, Iterable, Mapping, Union
 
 import torch
-from torchdrug.data import Graph, Molecule
+from torchdrug.data import Molecule
 
-from chemicalx.compat import PackedGraph
+from chemicalx.compat import Graph, PackedGraph
 
 __all__ = [
     "DrugFeatureSet",
@@ -43,5 +43,4 @@ class DrugFeatureSet(UserDict, Mapping[str, Mapping[str, Union[torch.FloatTensor
         :param drugs: A list of drug identifiers.
         :returns: The molecules batched together for message passing.
         """
-        # TODO hack this
         return Graph.pack([self.data[drug]["molecule"] for drug in drugs])

--- a/chemicalx/data/drugpairbatch.py
+++ b/chemicalx/data/drugpairbatch.py
@@ -5,7 +5,8 @@ from typing import Optional
 
 import pandas as pd
 import torch
-from torchdrug.data import PackedGraph
+
+from chemicalx.compat import PackedGraph
 
 __all__ = [
     "DrugPairBatch",

--- a/chemicalx/models/deepdds.py
+++ b/chemicalx/models/deepdds.py
@@ -26,10 +26,10 @@ from typing import List, Optional
 import torch
 from torch import nn
 from torch.nn.functional import normalize
-from torchdrug.data import PackedGraph
 from torchdrug.layers import MLP, MaxReadout
 from torchdrug.models import GraphConvolutionalNetwork
 
+from chemicalx.compat import PackedGraph
 from chemicalx.constants import TORCHDRUG_NODE_FEATURES
 from chemicalx.data import DrugPairBatch
 from chemicalx.models import Model

--- a/chemicalx/models/deepdrug.py
+++ b/chemicalx/models/deepdrug.py
@@ -2,9 +2,9 @@
 
 import torch
 from torch import nn
-from torchdrug.data import PackedGraph
 from torchdrug.layers import GraphConv, MaxReadout
 
+from chemicalx.compat import PackedGraph
 from chemicalx.constants import TORCHDRUG_NODE_FEATURES
 from chemicalx.data import DrugPairBatch
 from chemicalx.models import Model

--- a/chemicalx/models/epgcnds.py
+++ b/chemicalx/models/epgcnds.py
@@ -2,10 +2,10 @@
 
 import torch
 from torch import nn
-from torchdrug.data import PackedGraph
 from torchdrug.layers import MeanReadout
 from torchdrug.models import GraphConvolutionalNetwork
 
+from chemicalx.compat import PackedGraph
 from chemicalx.constants import TORCHDRUG_NODE_FEATURES
 from chemicalx.data import DrugPairBatch
 from chemicalx.models import Model

--- a/chemicalx/models/gcnbmp.py
+++ b/chemicalx/models/gcnbmp.py
@@ -1,6 +1,6 @@
 """An implementation of the GCNBMP model."""
 
-from typing import List, Optional, Tuple, Union
+from typing import List, Optional, Tuple, Union, cast
 
 import torch
 import torchdrug
@@ -196,8 +196,8 @@ class GCNBMP(Model):
     def unpack(self, batch: DrugPairBatch) -> Tuple[PackedGraph, PackedGraph]:
         """Return the left and right drugs PackedGraphs."""
         return (
-            batch.drug_molecules_left,
-            batch.drug_molecules_right,
+            cast(PackedGraph, batch.drug_molecules_left),
+            cast(PackedGraph, batch.drug_molecules_right),
         )
 
     def encoder_pass(self, molecules: PackedGraph) -> torch.FloatTensor:

--- a/chemicalx/models/gcnbmp.py
+++ b/chemicalx/models/gcnbmp.py
@@ -10,8 +10,8 @@ from torch.fft import fft, ifft
 from torch.nn import functional as F  # noqa:N812
 from torch_scatter import scatter_add
 from torchdrug import core, layers
-from torchdrug.data import PackedGraph
 
+from chemicalx.compat import PackedGraph
 from chemicalx.constants import TORCHDRUG_NODE_FEATURES
 from chemicalx.data import DrugPairBatch
 from chemicalx.models import Model

--- a/chemicalx/models/mrgnn.py
+++ b/chemicalx/models/mrgnn.py
@@ -3,10 +3,10 @@
 from typing import Any
 
 import torch
-from torchdrug.data import PackedGraph
 from torchdrug.layers import MeanReadout
 from torchdrug.models import GraphConvolutionalNetwork
 
+from chemicalx.compat import PackedGraph
 from chemicalx.constants import TORCHDRUG_NODE_FEATURES
 from chemicalx.data import DrugPairBatch
 from chemicalx.models import Model

--- a/chemicalx/models/ssiddi.py
+++ b/chemicalx/models/ssiddi.py
@@ -4,9 +4,9 @@ import torch
 import torch.nn.functional
 from torch.nn import LayerNorm
 from torch.nn.modules.container import ModuleList
-from torchdrug.data import PackedGraph
 from torchdrug.layers import GraphAttentionConv, MeanReadout
 
+from chemicalx.compat import PackedGraph
 from chemicalx.constants import TORCHDRUG_NODE_FEATURES
 from chemicalx.data import DrugPairBatch
 from chemicalx.models import Model

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -1,0 +1,41 @@
+"""Tests for compatibility layer."""
+
+import unittest
+
+import torch.cuda
+from torchdrug.data import Molecule
+
+from chemicalx.compat import Graph, PackedGraph
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "can not test compatibility layer without a GPU available")
+class TestCompat(unittest.TestCase):
+    """Tests for the compatibility layer."""
+
+    def setUp(self) -> None:
+        """Set up the test case."""
+        self.gpu_device = torch.device("cuda")
+
+    def test_packed_graph_device(self):
+        """Test the :func:`PackedGraph.to()`."""
+        structures = ["C(=O)O", "CCO"]
+        molecules = [Molecule.from_smiles(smiles) for smiles in structures]
+        packed_graph = Graph.pack(molecules)
+        self.assertIsInstance(packed_graph, PackedGraph)
+
+        self.assertEqual("cpu", packed_graph.edge_list.device.type)
+        self.assertEqual(
+            -1, packed_graph.edge_list.get_device(), msg="Device should be -1 to represent it's on the CPU"
+        )
+
+        gpu_packed_graph = packed_graph.to(self.gpu_device)
+        self.assertEqual("cuda", gpu_packed_graph.edge_list.device.type)
+        self.assertLessEqual(
+            0, gpu_packed_graph.edge_list.get_device(), msg="Device should 0 or higher for a cuda device"
+        )
+
+        self.assertIsNot(
+            packed_graph,
+            gpu_packed_graph,
+            msg="The PackedGraph.cuda() creates a new object. There is no in-place versions of this, unfortunately",
+        )


### PR DESCRIPTION
# Summary
 
This PR adds a compatibility layer for the packed graph class from torch drug while we're waiting for an upstream fix (https://github.com/DeepGraphLearning/torchdrug/pull/70). This layer makes sure there's a `to()` function that takes a device, as we usually expect torch stuff to do.
 
- [x] Unit tests provided for these changes
- [x] Documentation and docstrings added for these changes using the [sphinx style](https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html)

## Changes 

* Add a new module `chemicalx.compat`
* Implement a subclass of `torchdrug.data.PackedGraph` that implements the `to()` function
* Implement  subclass of `torchdrug.data.Graph` that uses the monkey patched PackedGraph when called in `chemicalx.data.drugfeatureset`