### PR TITLE
Documentation: Typo Fix

### DIFF
--- a/docs/source/notes/data_processing.rst
+++ b/docs/source/notes/data_processing.rst
@@ -3,7 +3,7 @@ Data Cleaning
 
 ChemicalX comes with benchmark datasets that we pre-processed.
 In this section of the documentation we discuss how we obtained the raw data.
-We also discuss hat pre-processing steps have been taken.
+We also discuss what pre-processing steps have been taken.
 We do this for each of the datasets in the framework.
 
 .. contents::


### PR DESCRIPTION
Closes #98 

# Summary
 
_Fixed a small typo within the documentation._
 
- [X] Unit tests provided for these changes
- [X] Documentation and docstrings added for these changes using the [sphinx style](https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html)

## Changes 

* _fixed typo within documentation of data_processing.rst_
