### PR TITLE
Update README and pin torchdrug to 0.1.2

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -63,7 +63,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
         with:
-          python-version: 3.7.12
+          python-version: 3.7
       - run: which python
       - name: Install general requirements
         run: |

--- a/README.md
+++ b/README.md
@@ -33,13 +33,21 @@
 If you find *ChemicalX* and the new datasets useful in your research, please consider adding the following citation:
 
 ```bibtex
-@article{chemicalx,
-  arxivId = {2202.05240},
-  author = {Rozemberczki, Benedek and Hoyt, Charles Tapley and Gogleva, Anna and Grabowski, Piotr and Karis, Klas and Lamov, Andrej and Nikolov, Andriy and Nilsson, Sebastian and Ughetto, Michael and Wang, Yu and Derr, Tyler and Gyori, Benjamin M},
-  month = {feb},
-  title = {{ChemicalX: A Deep Learning Library for Drug Pair Scoring}},
-  url = {http://arxiv.org/abs/2202.05240},
-  year = {2022}
+@inproceedings{10.1145/3534678.3539023,
+  author = {Rozemberczki, Benedek and Hoyt, Charles Tapley and Gogleva, Anna and Grabowski, Piotr and Karis, Klas and Lamov, Andrej and Nikolov, Andriy and Nilsson, Sebastian and Ughetto, Michael and Wang, Yu and Derr, Tyler and Gyori, Benjamin M.},
+  title = {ChemicalX: A Deep Learning Library for Drug Pair Scoring},
+  year = {2022},
+  isbn = {9781450393850},
+  publisher = {Association for Computing Machinery},
+  address = {New York, NY, USA},
+  url = {https://doi.org/10.1145/3534678.3539023},
+  doi = {10.1145/3534678.3539023},
+  booktitle = {Proceedings of the 28th ACM SIGKDD Conference on Knowledge Discovery and Data Mining},
+  pages = {3819–3828},
+  numpages = {10},
+  keywords = {chemistry, neural networks, deep learning},
+  location = {Washington DC, USA},
+  series = {KDD '22}
 }
 ```
 --------------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 [![Docs Status][docs-image]][docs-url]
 [![Code Coverage][coverage-image]][coverage-url]
 [![Build Status][build-image]][build-url]
-[![Arxiv](https://img.shields.io/badge/ArXiv-2202.05240-orange.svg)](https://arxiv.org/abs/2202.05240)
+[![DOI](https://img.shields.io/badge/DOI-10.1145/3534678.3539023-blue.svg)](https://bioregistry.io/doi:10.1145/3534678.3539023)
 
 **[Documentation](https://chemicalx.readthedocs.io)** | **[External Resources](https://chemicalx.readthedocs.io/en/latest/notes/resources.html)** | **[Datasets](https://chemicalx.readthedocs.io/en/latest/notes/introduction.html#datasets)** | **[Examples](https://github.com/AstraZeneca/chemicalx/tree/main/examples)** 
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 install_requires = [
     "numpy",
     "torch>=1.10.0",
-    "torchdrug",
+    "torchdrug==0.1.2",
     "torch-scatter>=2.0.8",
     "pandas<=1.3.5",
     "tqdm",


### PR DESCRIPTION
This PR does two things:

1. updates the citation from the preprint to the peer reviewed one
2. Pins the `torchdrug` version and closes #100 