### PR TITLE
Fix ci

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ from setuptools import find_packages, setup
 
 install_requires = [
     "numpy",
+    "rdkit-pypi<=2021.9.5.1",
     "torch>=1.10.0",
     "torchdrug==0.1.2",
     "torch-scatter>=2.0.8",

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ setup(
     setup_requires=setup_requires,
     tests_require=tests_require,
     extras_require=extras_require,
+    python_requires=">=3.7, <=3.9",
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",

--- a/tox.ini
+++ b/tox.ini
@@ -85,6 +85,9 @@ extras =
 commands =
     python -m sphinx -W -b html     -d build/doctrees source build/html
     python -m sphinx -W -b coverage -d build/doctrees source build/coverage
+whitelist_externals =
+    /bin/mkdir
+    /usr/bin/mkdir
 
 [testenv:doc8]
 skip_install = true

--- a/tox.ini
+++ b/tox.ini
@@ -70,7 +70,7 @@ commands =
     python -m sphinx -W -b coverage -d {envtmpdir}/build/doctrees {envtmpdir}/source {envtmpdir}/build/coverage
     cat {envtmpdir}/build/coverage/c.txt
     cat {envtmpdir}/build/coverage/python.txt
-whitelist_externals =
+allowlist_externals =
     /bin/cat
     /bin/cp
     /bin/mkdir
@@ -85,9 +85,6 @@ extras =
 commands =
     python -m sphinx -W -b html     -d build/doctrees source build/html
     python -m sphinx -W -b coverage -d build/doctrees source build/coverage
-whitelist_externals =
-    /bin/mkdir
-    /usr/bin/mkdir
 
 [testenv:doc8]
 skip_install = true


### PR DESCRIPTION
## Changes 

* renamed whitelist to allowlist in tox.ini as required by the tox package
* added python_requires to setup.py (now required)
* fixed a torchdrug 0.1.2's rdkit dependency to max 2021.9.5.1, newer rdkit installed by torchdrug 0.1.2 breaks some models
